### PR TITLE
ui: set titlebar style to hidden

### DIFF
--- a/main.js
+++ b/main.js
@@ -45,7 +45,8 @@ function setAPPListeners () {
  * Opens new window with index.html(Jitsi Meet is loaded in iframe there).
  */
 function createJitsiMeetWindow () {
-    jitsiMeetWindow = new BrowserWindow({width: 800, height: 600});
+    jitsiMeetWindow =
+        new BrowserWindow({width: 800, height: 600, titleBarStyle: 'hidden'});
     jitsiMeetWindow.loadURL(indexURL);
 
     jitsiMeetWindow.on("closed", () => {


### PR DESCRIPTION
We have just enough space for the titlebar buttons.  This simplifies things, because if we go with a frameless window we's have to implement the buttons and dragging ourselves.

![screen shot 2017-02-07 at 00 05 55](https://cloud.githubusercontent.com/assets/317464/22670555/01afcc4c-ecca-11e6-8475-b13c52f37d61.png)
