### PR TITLE
Avoid certificate checks when loading localhost

### DIFF
--- a/main.js
+++ b/main.js
@@ -50,6 +50,16 @@ function setAPPListeners () {
             createJitsiMeetWindow();
         }
     });
+    APP.on('certificate-error',
+        (event, webContents, url, error, certificate, callback) => {
+            if (url.startsWith('https://localhost')) {
+                event.preventDefault();
+                callback(true);
+            } else {
+                callback(false);
+            }
+        }
+    );
 }
 
 /**


### PR DESCRIPTION
Helps with testing, since the webpack dev server uses a self-signed
certificate.