### PR TITLE
ui: open default browser on hyperlink

### DIFF
--- a/main.js
+++ b/main.js
@@ -68,6 +68,13 @@ function setAPPListeners () {
 function createJitsiMeetWindow () {
     jitsiMeetWindow = new BrowserWindow(jitsiMeetWindowOptions);
     jitsiMeetWindow.loadURL(indexURL);
+    let contents = jitsiMeetWindow.webContents;
+    let shell = electron.shell;
+
+    contents.on('new-window', function(event, url) {
+        event.preventDefault();
+        shell.openExternal(url);
+    });
 
     jitsiMeetWindow.on("closed", () => {
         jitsiMeetWindow = null;

--- a/main.js
+++ b/main.js
@@ -68,12 +68,10 @@ function setAPPListeners () {
 function createJitsiMeetWindow () {
     jitsiMeetWindow = new BrowserWindow(jitsiMeetWindowOptions);
     jitsiMeetWindow.loadURL(indexURL);
-    let contents = jitsiMeetWindow.webContents;
-    let shell = electron.shell;
 
-    contents.on('new-window', function(event, url) {
+    jitsiMeetWindow.webContents.on('new-window', function(event, url) {
         event.preventDefault();
-        shell.openExternal(url);
+        electron.shell.openExternal(url);
     });
 
     jitsiMeetWindow.on("closed", () => {


### PR DESCRIPTION
When a new window is opened by a hyperlink, open in the default browser instead of electron browser.