### PR TITLE
Add homebrew cask formula for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ sudo apt-get install libnss3
 
 </details>
 
+### Homebrew
+
+For *MacOS* user, you can install the application using the following command:
+
+```
+brew cask install jitsi-meet
+```
+
 ### Using it with your own Jitsi Meet installation
 
 In order to use this application with your own Jitsi Meet installation it's


### PR DESCRIPTION
It was not clear that the cask formula was available for this promising app: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/jitsi-meet.rb