### PR TITLE
Fix typo in onboarding boxes

### DIFF
--- a/app/features/onboarding/components/AlwaysOnTopWindowSpotlight.js
+++ b/app/features/onboarding/components/AlwaysOnTopWindowSpotlight.js
@@ -49,7 +49,7 @@ class AlwaysOnTopWindowSpotlight extends Component<Props, *> {
                 ] }
                 dialogPlacement = 'left top'
                 target = { 'always-on-top-window' } >
-                You can toggle if you want to eenable the "always-on-top" window
+                You can toggle whether you want to enable the "always-on-top" window,
                 which is displayed when the main window loses focus.
                 This will be applied to all conferences.
             </Spotlight>


### PR DESCRIPTION
I'm also not entirely sure what this option does. Afaict on GNOME 3.36.1 / Manjaro Linux when having this option on, in a video call with one other participant, if I defocus the jitsi electron screen, no always-on-top window appears.