### PR TITLE
Add support for query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ npm install
 npm start
 ```
 
+The debugger tools are available when running in dev mode and can be activated with keyboard shortcuts as defined here https://github.com/sindresorhus/electron-debug#features.
+
 #### Building the production distribution
 
 ```bash

--- a/app/features/conference/components/Conference.js
+++ b/app/features/conference/components/Conference.js
@@ -241,19 +241,27 @@ class Conference extends Component<Props, State> {
      */
     _onScriptLoad(parentNode: Object) {
         const JitsiMeetExternalAPI = window.JitsiMeetExternalAPI;
-
+        const url = new URL(this._conference.room, this._conference.serverURL);
+        const roomName = url.pathname.split('/').pop();
         const host = this._conference.serverURL.replace(/https?:\/\//, '');
+        const searchParameters = Object.fromEntries(url.searchParams);
+        const urlParameters = Object.keys(searchParameters).length ? searchParameters : {};
 
         const configOverwrite = {
             startWithAudioMuted: this.props._startWithAudioMuted,
             startWithVideoMuted: this.props._startWithVideoMuted
         };
 
-        this._api = new JitsiMeetExternalAPI(host, {
+        const options = {
             configOverwrite,
             onload: this._onIframeLoad,
             parentNode,
-            roomName: this._conference.room
+            roomName
+        };
+
+        this._api = new JitsiMeetExternalAPI(host, {
+            ...options,
+            ...urlParameters
         });
 
         const { RemoteControl,

--- a/app/features/welcome/components/Welcome.js
+++ b/app/features/welcome/components/Welcome.js
@@ -200,7 +200,7 @@ class Welcome extends Component<Props, State> {
                             isInvalid = { locationError }
                             isLabelHidden = { true }
                             onChange = { this._onURLChange }
-                            placeholder = 'Enter a name for your conference'
+                            placeholder = 'Enter a name for your conference or a Jitsi URL'
                             shouldFitContainer = { true }
                             type = 'text'
                             value = { this.state.url } />


### PR DESCRIPTION
Hello everybody,

This PR adds the support for query parameters in the Jitsi URL in order to fill extra fields in `options` when calling `api = new JitsiMeetExternalAPI(domain, options)`.

The initial usecase was to be able to open conference with a JWT token: The `options.jwt` parameter is set from the `?jwt=` query parameter. This usecase has been validated, you can open a room protected with jwt with an input URL like `https://HOST:PORT/ROOM?jwt=TOKEN`.
This is compliant with browser-based JWT protected rooms where the `jwt` token is also defined as query parameter.

The approach is quite generic and allows simple parameters in `options` to be defined from the user. While there is nothing more than a simple input field available to create a room, this is the only approach which allows to pass other parameters. Anyway, if you think that it is too much generic, I am OK to change the code to support only a set of query parameters instead of overriding all the options with input ones.

