### PR TITLE
macOS Catalina Fix for Camera/Microphone

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,12 @@
     "mac": {
       "artifactName": "jitsi-meet.${ext}",
       "category": "public.app-category.video",
-      "darkModeSupport": true
+      "darkModeSupport": true,
+      "hardenedRuntime": false,
+      "extendInfo": {
+        "NSCameUsageDescription": "jitsi meet requires access to your camera in order to make video-calls.",
+        "NSMicrophoneUsageDescription": "jitsi meet requires access to your microphone in order to make calls (audio/video)."
+      }
     },
     "linux": {
       "artifactName": "jitsi-meet-${arch}.${ext}",


### PR DESCRIPTION
Without the "extendInfo" and "hardenedRuntime=false", the OS doesn't even ask for permission for camera & microphone when the client is started first time on macOS Catalina. The "extendInfo" provides the messages describing why we need access to camera/microphone. 