### PR TITLE
Catalina fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4006,9 +4006,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -9086,9 +9086,9 @@
       }
     },
     "node-abi": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.15.0.tgz",
-      "integrity": "sha512-FeLpTS0F39U7hHZU1srAK4Vx+5AHNVOTP+hxBNQknR/54laTHSFIJkDWDqiquY1LeLUgTfPN7sLPhMubx0PLAg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.16.0.tgz",
+      "integrity": "sha512-+sa0XNlWDA6T+bDLmkCUYn6W5k5W6BPRL6mqzSCs6H/xUgtl4D5x2fORKDzopKiU6wsyn/+wXlRXwXeSp+mtoA==",
       "requires": {
         "semver": "^5.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,12 @@
     "mac": {
       "artifactName": "jitsi-meet.${ext}",
       "category": "public.app-category.video",
-      "darkModeSupport": true
+      "darkModeSupport": true,
+      "hardenedRuntime": false,
+      "extendInfo": {
+        "NSCameUsageDescription": "jitsi meet requires access to your camera in order to make video-calls.",
+        "NSMicrophoneUsageDescription": "jitsi meet requires access to your microphone in order to make calls (audio/video)."
+      }
     },
     "linux": {
       "artifactName": "jitsi-meet-${arch}.${ext}",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
       "darkModeSupport": true,
       "hardenedRuntime": false,
       "extendInfo": {
-        "NSCameUsageDescription": "jitsi meet requires access to your camera in order to make video-calls.",
-        "NSMicrophoneUsageDescription": "jitsi meet requires access to your microphone in order to make calls (audio/video)."
+        "NSCameraUsageDescription": "Jitsi Meet requires access to your camera in order to make video-calls.",
+        "NSMicrophoneUsageDescription": "Jitsi Meet requires access to your microphone in order to make calls (audio/video)."
       }
     },
     "linux": {


### PR DESCRIPTION
Fixed an issue with macOS Catalina requiring additional meta information before allowing Camera/Microphone usage. Also, the "hardenedRuntime" needs to be disabled, otherwise it will require notarization.