### PR TITLE
Fix shortcuts on macOS

### DIFF
--- a/main.js
+++ b/main.js
@@ -51,13 +51,18 @@ function setApplicationMenu() {
     if (process.platform === 'darwin') {
         const template = [ {
             label: app.name,
-            submenu: [ {
-                label: 'Quit',
-                accelerator: 'Command+Q',
-                click() {
-                    app.quit();
-                }
-            } ]
+            submenu: [
+                {
+                    role: 'services',
+                    submenu: []
+                },
+                { type: 'separator' },
+                { role: 'hide' },
+                { role: 'hideothers' },
+                { role: 'unhide' },
+                { type: 'separator' },
+                { role: 'quit' }
+            ]
         }, {
             label: 'Edit',
             submenu: [ {
@@ -92,7 +97,13 @@ function setApplicationMenu() {
                 label: 'Select All',
                 accelerator: 'CmdOrCtrl+A',
                 selector: 'selectAll:'
-            }
+            } ]
+        }, {
+            label: '&Window',
+            role: 'window',
+            submenu: [
+                { role: 'minimize' },
+                { role: 'close' }
             ]
         } ];
 


### PR DESCRIPTION
The regular windows shortcuts (eg. minimise, hide) don't work unless
they have menu entries, so add them along with the standard set of
expected menu items for mac (although I've omitted 'about' since it
opens a window so is a slightly more visible change).

Also Electron has a role for 'quit' so use this instead of providing
our own.