### PR TITLE
Add SHOW_DEV_TOOLS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ It can also be displayed automatically from the `SHOW_DEV_TOOLS` environment var
 SHOW_DEV_TOOLS=true npm start
 ```
 
+or from the application `--show-dev-tools` command line flag.
+
 #### Building the production distribution
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ npm start
 
 The debugger tools are available when running in dev mode and can be activated with keyboard shortcuts as defined here https://github.com/sindresorhus/electron-debug#features.
 
+It can also be displayed automatically from the `SHOW_DEV_TOOLS` environment variable such as:
+
+```bash
+SHOW_DEV_TOOLS=true npm start
+```
+
 #### Building the production distribution
 
 ```bash

--- a/main.js
+++ b/main.js
@@ -21,7 +21,7 @@ const path = require('path');
 const URL = require('url');
 const config = require('./app/features/config');
 
-const showDevTools = Boolean(process.env.SHOW_DEV_TOOLS);
+const showDevTools = Boolean(process.env.SHOW_DEV_TOOLS) || (process.argv.indexOf('--show-dev-tools') > -1);
 
 // We need this because of https://github.com/electron/electron/issues/18214
 app.commandLine.appendSwitch('disable-site-isolation-trials');

--- a/main.js
+++ b/main.js
@@ -21,6 +21,8 @@ const path = require('path');
 const URL = require('url');
 const config = require('./app/features/config');
 
+const showDevTools = Boolean(process.env.SHOW_DEV_TOOLS);
+
 // We need this because of https://github.com/electron/electron/issues/18214
 app.commandLine.appendSwitch('disable-site-isolation-trials');
 
@@ -38,7 +40,7 @@ autoUpdater.logger.transports.file.level = 'info';
 // show them automatically though.
 debug({
     isEnabled: true,
-    showDevTools: false
+    showDevTools
 });
 
 /**


### PR DESCRIPTION
This PR allows to open devtools from the command line when launching the application such as:

```sh
SHOW_DEV_TOOLS=true npm start
```

It also adds the command line support when launching app (https://www.electronjs.org/docs/api/command-line) with `--show-dev-tools`