### PR TITLE
Add protocol to open conference links with the app - Replaces #263

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Desktop application for [Jitsi Meet] built with [Electron].
 - Builtin auto-updates
 - Remote control
 - Always-On-Top window
+- Support for deeplinks such as `jitsi-meet://myroom` (will open `myroom` on the configured Jitsi instance) or `jitsi-meet://jitsi.mycompany.com/myroom` (will open `myroom` on the Jitsi instance running on `jitsi.mycompany.com`)
 
 ## Installation
 

--- a/app/features/app/components/App.js
+++ b/app/features/app/components/App.js
@@ -62,13 +62,28 @@ class App extends Component<*> {
     /**
      * Handler when main proccess contact us.
      *
-     * @param {Object} event - Message event triggered by .
-     * @param {Object} arg - String with room and optionally server url.
+     * @param {Object} event - Message event.
+     * @param {string} inputURL - String with room name.
      *
      * @returns {void}
      */
-    _listenOnProtocolMessages(event, arg) {
-        const conference = createConferenceObjectFromURL(arg);
+    _listenOnProtocolMessages(event, inputURL: string) {
+        let room;
+
+        // Remove trailing slash if one exists.
+        if (inputURL.substr(-1) === '/') {
+            inputURL = inputURL.substr(0, inputURL.length - 1); // eslint-disable-line no-param-reassign
+        }
+
+        // To avoid potential phishing attacks, we allow only room to
+        // be sent from the app link and use server from app settings.
+        if (inputURL.includes('/')) {
+            room = inputURL.split('/').pop();
+        } else {
+            room = inputURL;
+        }
+
+        const conference = createConferenceObjectFromURL(room);
 
         // Don't navigate if conference couldn't be created
         if (!conference) {

--- a/app/features/app/components/App.js
+++ b/app/features/app/components/App.js
@@ -4,26 +4,79 @@ import { AtlasKitThemeProvider } from '@atlaskit/theme';
 
 import React, { Component } from 'react';
 import { Route, Switch } from 'react-router';
-import { ConnectedRouter as Router } from 'react-router-redux';
+import { connect } from 'react-redux';
+import { ConnectedRouter as Router, push } from 'react-router-redux';
 
 import { Conference } from '../../conference';
 import config from '../../config';
 import { history } from '../../router';
+import { createConferenceObjectFromURL } from '../../utils';
 import { Welcome } from '../../welcome';
 
 /**
  * Main component encapsulating the entire application.
  */
-export default class App extends Component<*> {
+class App extends Component<*> {
     /**
      * Initializes a new {@code App} instance.
      *
      * @inheritdoc
      */
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
 
         document.title = config.appName;
+
+        this._listenOnProtocolMessages
+            = this._listenOnProtocolMessages.bind(this);
+    }
+
+    /**
+     * Implements React's {@link Component#componentDidMount()}.
+     *
+     * @returns {void}
+     */
+    componentDidMount() {
+        // start listening on this events
+        window.jitsiNodeAPI.ipcRenderer.on('protocol-data-msg', this._listenOnProtocolMessages);
+
+        // send notification to main process
+        window.jitsiNodeAPI.ipcRenderer.send('renderer-ready');
+    }
+
+    /**
+     * Implements React's {@link Component#componentWillUnmount()}.
+     *
+     * @returns {void}
+     */
+    componentWillUnmount() {
+        // remove listening for this events
+        window.jitsiNodeAPI.ipcRenderer.removeListener(
+            'protocol-data-msg',
+            this._listenOnProtocolMessages
+        );
+    }
+
+    _listenOnProtocolMessages: (*) => void;
+
+    /**
+     * Handler when main proccess contact us.
+     *
+     * @param {Object} event - Message event triggered by .
+     * @param {Object} arg - String with room and optionally server url.
+     *
+     * @returns {void}
+     */
+    _listenOnProtocolMessages(event, arg) {
+        const conference = createConferenceObjectFromURL(arg);
+
+        // Don't navigate if conference couldn't be created
+        if (!conference) {
+            return;
+        }
+
+        // change route when we are notified
+        this.props.dispatch(push('/conference', conference));
     }
 
     /**
@@ -50,3 +103,5 @@ export default class App extends Component<*> {
         );
     }
 }
+
+export default connect()(App);

--- a/app/features/app/components/App.js
+++ b/app/features/app/components/App.js
@@ -51,7 +51,7 @@ class App extends Component<*> {
      */
     componentWillUnmount() {
         // remove listening for this events
-        window.jitsiNodeAPI.ipc.on(
+        window.jitsiNodeAPI.ipc.removeListener(
             'protocol-data-msg',
             this._listenOnProtocolMessages
         );

--- a/app/features/app/components/App.js
+++ b/app/features/app/components/App.js
@@ -38,10 +38,10 @@ class App extends Component<*> {
      */
     componentDidMount() {
         // start listening on this events
-        window.jitsiNodeAPI.ipcRenderer.on('protocol-data-msg', this._listenOnProtocolMessages);
+        window.jitsiNodeAPI.ipc.on('protocol-data-msg', this._listenOnProtocolMessages);
 
         // send notification to main process
-        window.jitsiNodeAPI.ipcRenderer.send('renderer-ready');
+        window.jitsiNodeAPI.ipc.send('renderer-ready');
     }
 
     /**
@@ -51,7 +51,7 @@ class App extends Component<*> {
      */
     componentWillUnmount() {
         // remove listening for this events
-        window.jitsiNodeAPI.ipcRenderer.removeListener(
+        window.jitsiNodeAPI.ipc.on(
             'protocol-data-msg',
             this._listenOnProtocolMessages
         );

--- a/app/features/app/components/App.js
+++ b/app/features/app/components/App.js
@@ -68,22 +68,12 @@ class App extends Component<*> {
      * @returns {void}
      */
     _listenOnProtocolMessages(event, inputURL: string) {
-        let room;
-
         // Remove trailing slash if one exists.
         if (inputURL.substr(-1) === '/') {
             inputURL = inputURL.substr(0, inputURL.length - 1); // eslint-disable-line no-param-reassign
         }
 
-        // To avoid potential phishing attacks, we allow only room to
-        // be sent from the app link and use server from app settings.
-        if (inputURL.includes('/')) {
-            room = inputURL.split('/').pop();
-        } else {
-            room = inputURL;
-        }
-
-        const conference = createConferenceObjectFromURL(room);
+        const conference = createConferenceObjectFromURL(inputURL);
 
         // Don't navigate if conference couldn't be created
         if (!conference) {

--- a/app/features/config/index.js
+++ b/app/features/config/index.js
@@ -16,6 +16,12 @@ export default {
     appName: 'Jitsi Meet',
 
     /**
+    * The prefix for application protocol.
+    * You will also need to replace this in package.json.
+    */
+    appProtocolPrefix: 'jitsi',
+
+    /**
      * The default server URL of Jitsi Meet Deployment that will be used.
      */
     defaultServerURL: 'https://meet.jit.si',

--- a/app/features/config/index.js
+++ b/app/features/config/index.js
@@ -19,7 +19,7 @@ export default {
     * The prefix for application protocol.
     * You will also need to replace this in package.json.
     */
-    appProtocolPrefix: 'jitsi',
+    appProtocolPrefix: 'jitsi-meet',
 
     /**
      * The default server URL of Jitsi Meet Deployment that will be used.

--- a/app/features/utils/functions.js
+++ b/app/features/utils/functions.js
@@ -63,19 +63,22 @@ export function openExternalLink(link: string) {
  * @returns {Object}
  */
 export function createConferenceObjectFromURL(inputURL: string) {
+    const lastIndexOfSlash = inputURL.lastIndexOf('/');
     let room;
+    let serverURL;
 
-    // Remove trailing slash if exists.
-    if (inputURL.substr(-1) === '/') {
-        inputURL = inputURL.substr(0, inputURL.length - 1); // eslint-disable-line no-param-reassign
-    }
-
-    // If we have more then a room name here,
-    // we assume that the last one is a room name.
-    if (inputURL.includes('/')) {
-        room = inputURL.split('/').pop();
-    } else {
+    if (lastIndexOfSlash === -1) {
+        // This must be only the room name.
         room = inputURL;
+    } else {
+        // Take the substring after last slash to be the room name.
+        room = inputURL.substring(lastIndexOfSlash + 1);
+
+        // Take the substring before last slash to be the Server URL.
+        serverURL = inputURL.substring(0, lastIndexOfSlash);
+
+        // Normalize the server URL.
+        serverURL = normalizeServerURL(serverURL);
     }
 
     // Don't navigate if no room was specified.
@@ -84,6 +87,7 @@ export function createConferenceObjectFromURL(inputURL: string) {
     }
 
     return {
-        room
+        room,
+        serverURL
     };
 }

--- a/app/features/utils/functions.js
+++ b/app/features/utils/functions.js
@@ -54,3 +54,36 @@ export function normalizeServerURL(url: string) {
 export function openExternalLink(link: string) {
     window.jitsiNodeAPI.openExternalLink(link);
 }
+
+
+/**
+ * Get URL, extract room name from it and create a Conference object.
+ *
+ * @param {string} inputURL - Combined server url with room separated by /.
+ * @returns {Object}
+ */
+export function createConferenceObjectFromURL(inputURL: string) {
+    let room;
+
+    // Remove trailing slash if exists.
+    if (inputURL.substr(-1) === '/') {
+        inputURL = inputURL.substr(0, inputURL.length - 1); // eslint-disable-line no-param-reassign
+    }
+
+    // If we have more then a room name here,
+    // we assume that the last one is a room name.
+    if (inputURL.includes('/')) {
+        room = inputURL.split('/').pop();
+    } else {
+        room = inputURL;
+    }
+
+    // Don't navigate if no room was specified.
+    if (!room) {
+        return;
+    }
+
+    return {
+        room
+    };
+}

--- a/app/features/welcome/components/Welcome.js
+++ b/app/features/welcome/components/Welcome.js
@@ -15,7 +15,7 @@ import { push } from 'react-router-redux';
 import { Navbar } from '../../navbar';
 import { Onboarding, startOnboarding } from '../../onboarding';
 import { RecentList } from '../../recent-list';
-import { normalizeServerURL } from '../../utils';
+import { createConferenceObjectFromURL } from '../../utils';
 
 import { Body, FieldWrapper, Form, Header, Label, Wrapper } from '../styled';
 
@@ -206,28 +206,14 @@ class Welcome extends Component<Props, State> {
      */
     _onJoin() {
         const inputURL = this.state.url || this.state.generatedRoomname;
-        const lastIndexOfSlash = inputURL.lastIndexOf('/');
-        let room;
-        let serverURL;
+        const conference = createConferenceObjectFromURL(inputURL);
 
-        if (lastIndexOfSlash === -1) {
-            // This must be only the room name.
-            room = inputURL;
-        } else {
-            // Take the substring after last slash to be the room name.
-            room = inputURL.substring(lastIndexOfSlash + 1);
-
-            // Take the substring before last slash to be the Server URL.
-            serverURL = inputURL.substring(0, lastIndexOfSlash);
-
-            // Normalize the server URL.
-            serverURL = normalizeServerURL(serverURL);
+        // Don't navigate if conference couldn't be created
+        if (!conference) {
+            return;
         }
 
-        this.props.dispatch(push('/conference', {
-            room,
-            serverURL
-        }));
+        this.props.dispatch(push('/conference', conference));
     }
 
     _onURLChange: (*) => void;

--- a/app/features/welcome/components/Welcome.js
+++ b/app/features/welcome/components/Welcome.js
@@ -224,11 +224,6 @@ class Welcome extends Component<Props, State> {
             serverURL = normalizeServerURL(serverURL);
         }
 
-        // Don't navigate if no room was specified.
-        if (!room) {
-            return;
-        }
-
         this.props.dispatch(push('/conference', {
             room,
             serverURL

--- a/app/preload/preload.js
+++ b/app/preload/preload.js
@@ -5,7 +5,6 @@ const url = require('url');
 
 const jitsiMeetElectronUtils = require('jitsi-meet-electron-utils');
 
-
 const protocolRegex = /^https?:/i;
 
 /**
@@ -28,6 +27,7 @@ function openExternalLink(link) {
     }
 }
 
+const whitelistedIpcChannels = [ 'protocol-data-msg', 'renderer-ready' ];
 
 window.jitsiNodeAPI = {
     createElectronStorage,
@@ -35,5 +35,27 @@ window.jitsiNodeAPI = {
     openExternalLink,
     jitsiMeetElectronUtils,
     shellOpenExternal: shell.openExternal,
-    ipcRenderer
+    ipc: {
+        on: (channel, listener) => {
+            if (!whitelistedIpcChannels.includes(channel)) {
+                return;
+            }
+
+            return ipcRenderer.on(channel, listener);
+        },
+        send: channel => {
+            if (!whitelistedIpcChannels.includes(channel)) {
+                return;
+            }
+
+            return ipcRenderer.send(channel);
+        },
+        removeListener: (channel, listener) => {
+            if (!whitelistedIpcChannels.includes(channel)) {
+                return;
+            }
+
+            return ipcRenderer.removeListener(channel, listener);
+        }
+    }
 };

--- a/app/preload/preload.js
+++ b/app/preload/preload.js
@@ -1,5 +1,5 @@
 const createElectronStorage = require('redux-persist-electron-storage');
-const { shell } = require('electron');
+const { ipcRenderer, shell } = require('electron');
 const os = require('os');
 const url = require('url');
 
@@ -33,5 +33,7 @@ window.jitsiNodeAPI = {
     createElectronStorage,
     osUserInfo: os.userInfo,
     openExternalLink,
-    jitsiMeetElectronUtils
+    jitsiMeetElectronUtils,
+    shellOpenExternal: shell.openExternal,
+    ipcRenderer
 };

--- a/main.js
+++ b/main.js
@@ -227,7 +227,6 @@ function createJitsiMeetWindow() {
      *  while app is closed
      * it will trigger this event below
      */
-    handleProtocolCall(process.argv[2]);
     if (process.platform === 'win32') {
         handleProtocolCall(process.argv.pop());
     }

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ const {
     BrowserWindow,
     Menu,
     app,
+    ipcMain,
     shell
 } = require('electron');
 const contextMenu = require('electron-context-menu');
@@ -70,6 +71,14 @@ if (isDev) {
  * acidentally.
  */
 let mainWindow = null;
+
+/**
+ * Add protocol data
+ */
+const appProtocolSurplus = `${config.default.appProtocolPrefix}://`;
+let rendererReady = false;
+let protocolDataForFrontApp = null;
+
 
 /**
  * Sets the application menu. It is hidden on all platforms except macOS because
@@ -211,6 +220,42 @@ function createJitsiMeetWindow() {
     mainWindow.once('ready-to-show', () => {
         mainWindow.show();
     });
+
+    /**
+     * This is for windows [win32]
+     * so when someone tries to enter something like jitsi://test
+     *  while app is closed
+     * it will trigger this event below
+     */
+    handleProtocolCall(process.argv[2]);
+}
+
+/**
+ * Handler for application protocol links to initiate a conference.
+ */
+function handleProtocolCall(fullProtocolCall) {
+    // don't touch when something is bad
+    if (
+        !fullProtocolCall
+        || fullProtocolCall.trim() === ''
+        || fullProtocolCall.indexOf(appProtocolSurplus) !== 0
+    ) {
+        return;
+    }
+
+    const inputURL = fullProtocolCall.replace(appProtocolSurplus, '');
+
+    if (app.isReady() && mainWindow === null) {
+        createJitsiMeetWindow();
+    }
+
+    protocolDataForFrontApp = inputURL;
+
+    if (rendererReady) {
+        mainWindow
+            .webContents
+            .send('protocol-data-msg', inputURL);
+    }
 }
 
 /**
@@ -247,7 +292,7 @@ app.on('certificate-error',
 
 app.on('ready', createJitsiMeetWindow);
 
-app.on('second-instance', () => {
+app.on('second-instance', (event, commandLine) => {
     /**
      * If someone creates second instance of the application, set focus on
      * existing window.
@@ -255,6 +300,13 @@ app.on('second-instance', () => {
     if (mainWindow) {
         mainWindow.isMinimized() && mainWindow.restore();
         mainWindow.focus();
+
+        /**
+         * This is for windows [win32]
+         * so when someone tries to enter something like jitsi://test
+         * while app is opened it will trigger protocol handler.
+         */
+        handleProtocolCall(commandLine[2]);
     }
 });
 
@@ -262,5 +314,43 @@ app.on('window-all-closed', () => {
     // Don't quit the application on macOS.
     if (process.platform !== 'darwin') {
         app.quit();
+    }
+});
+
+// remove so we can register each time as we run the app.
+app.removeAsDefaultProtocolClient(config.default.appProtocolPrefix);
+
+// If we are running a non-packaged version of the app && on windows
+if (isDev && process.platform === 'win32') {
+    // Set the path of electron.exe and your app.
+    // These two additional parameters are only available on windows.
+    app.setAsDefaultProtocolClient(
+        config.default.appProtocolPrefix,
+        process.execPath,
+        [ path.resolve(process.argv[1]) ]
+    );
+} else {
+    app.setAsDefaultProtocolClient(config.default.appProtocolPrefix);
+}
+
+/**
+ * This is for mac [darwin]
+ * so when someone tries to enter something like jitsi://test
+ * it will trigger this event below
+ */
+app.on('open-url', (event, data) => {
+    event.preventDefault();
+    handleProtocolCall(data);
+});
+
+/**
+ * This is to notify main.js [this] that front app is ready to receive messages.
+ */
+ipcMain.on('renderer-ready', () => {
+    rendererReady = true;
+    if (protocolDataForFrontApp) {
+        mainWindow
+            .webContents
+            .send('protocol-data-msg', protocolDataForFrontApp);
     }
 });

--- a/main.js
+++ b/main.js
@@ -223,11 +223,14 @@ function createJitsiMeetWindow() {
 
     /**
      * This is for windows [win32]
-     * so when someone tries to enter something like jitsi://test
+     * so when someone tries to enter something like jitsi-meet://test
      *  while app is closed
      * it will trigger this event below
      */
     handleProtocolCall(process.argv[2]);
+    if (process.platform === 'win32') {
+        handleProtocolCall(process.argv.pop());
+    }
 }
 
 /**
@@ -303,10 +306,10 @@ app.on('second-instance', (event, commandLine) => {
 
         /**
          * This is for windows [win32]
-         * so when someone tries to enter something like jitsi://test
+         * so when someone tries to enter something like jitsi-meet://test
          * while app is opened it will trigger protocol handler.
          */
-        handleProtocolCall(commandLine[2]);
+        handleProtocolCall(commandLine.pop());
     }
 });
 
@@ -335,7 +338,7 @@ if (isDev && process.platform === 'win32') {
 
 /**
  * This is for mac [darwin]
- * so when someone tries to enter something like jitsi://test
+ * so when someone tries to enter something like jitsi-meet://test
  * it will trigger this event below
  */
 app.on('open-url', (event, data) => {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,16 @@
     },
     "directories": {
       "buildResources": "resources"
-    }
+    },
+    "protocols": [
+      {
+        "name": "jitsi-protocol",
+        "role": "Viewer",
+        "schemes": [
+          "jitsi"
+        ]
+      }
+    ]
   },
   "pre-commit": [
     "lint"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "name": "jitsi-protocol",
         "role": "Viewer",
         "schemes": [
-          "jitsi"
+          "jitsi-meet"
         ]
       }
     ]


### PR DESCRIPTION
This PR replaces https://github.com/jitsi/jitsi-meet-electron/pull/263.

It fixes several things:

- support for Jitsi server definition in jitsi-meet:// URLs
- README mention of the feature
- Fix bad protocol handling
- Rebased on master

If you want to keep the other PR and merge it, please do it on a feature branch. I will update this one to keep only the right commits
