### PR TITLE
Increase default timeout to 30 seconds

### DIFF
--- a/app/features/config/index.js
+++ b/app/features/config/index.js
@@ -29,7 +29,7 @@ export default {
     /**
      * The default server Timeout in seconds.
      */
-    defaultServerTimeout: 10,
+    defaultServerTimeout: 30,
 
     /**
      * URL to send feedback.


### PR DESCRIPTION
Hello,

We have many small deployments where the default timeout to 10 seconds is not enough at all.
30 seconds will be more than enough and will avoid having unexpected errors. BTW, the error is not clear, going to create a PR so it is more explicit.