### PR TITLE
Fix join via protocol link on Linux

### DIFF
--- a/main.js
+++ b/main.js
@@ -222,14 +222,11 @@ function createJitsiMeetWindow() {
     });
 
     /**
-     * This is for windows [win32]
-     * so when someone tries to enter something like jitsi-meet://test
+     * When someone tries to enter something like jitsi-meet://test
      *  while app is closed
      * it will trigger this event below
      */
-    if (process.platform === 'win32') {
-        handleProtocolCall(process.argv.pop());
-    }
+    handleProtocolCall(process.argv.pop());
 }
 
 /**


### PR DESCRIPTION
Perform command-line protocol argument handling on all platforms, not only
win32. This allows the client to join a meeting passed on the command-line
even if no instance of the client is already running.

Resolves #411