### PR TITLE
64-bit in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Desktop application for [Jitsi Meet] built with [Electron].
 
 Download our latest release and you're off to the races!
 
-| Windows | macOS | GNU/Linux (64bits only) |
+| Windows | macOS | GNU/Linux (64-bit only) |
 | -- | -- | -- |
 | [Download](https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.exe) | [Download](https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.dmg) | [Download](https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet-x86_64.AppImage) |
 


### PR DESCRIPTION
`64bits` should be [64-bit](https://en.wikipedia.org/wiki/64-bit_computing)
https://github.com/jitsi/jitsi-meet-electron/pull/428#issuecomment-668258708