### PR TITLE
Update openExternalLink.js

### DIFF
--- a/app/features/utils/openExternalLink.js
+++ b/app/features/utils/openExternalLink.js
@@ -2,7 +2,7 @@ const { shell } = require('electron');
 const url = require('url');
 
 
-const protocolRegex = /^https?:/i;
+const protocolRegex = /^(https?|mailto):/i;
 
 /**
  * Opens the given link in an external browser.


### PR DESCRIPTION
Allows opening mailto links.
Fix issue [#477](https://github.com/jitsi/jitsi-meet-electron/issues/477#issue-743628544)