### PR TITLE
Update Electron to fix i18n on macOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7512,9 +7512,9 @@
       }
     },
     "electron": {
-      "version": "10.1.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-10.1.6.tgz",
-      "integrity": "sha512-Wyiq5Fy64KAa51i72m+5zayYKSm9O5lnittUdaElAn3PAzGl3yDifYO2QsXR7k/iKxWVSROOPzf43mXYytL67Q==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-11.1.1.tgz",
+      "integrity": "sha512-tlbex3xosJgfileN6BAQRotevPRXB/wQIq48QeQ08tUJJrXwE72c8smsM/hbHx5eDgnbfJ2G3a60PmRjHU2NhA==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -9267,9 +9267,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.0.tgz",
-          "integrity": "sha512-W2VYNB0nwQQE7tKS7HzXd7r2y/y2SVJl4ga6oH/dnaLFzM0o2lB2P3zCkWj5Wc/zyMYjtgd5Hmhk0ObkQFZOIA==",
+          "version": "3.8.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.2.tgz",
+          "integrity": "sha512-FfApuSRgrR6G5s58casCBd9M2k+4ikuu4wbW6pJyYU7bd9zvFc9qf7vr5xmrZOhT9nn+8uwlH1oRR9jTnFoA3A==",
           "dev": true,
           "optional": true
         },
@@ -13626,9 +13626,9 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "requires": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "babel-loader": "8.1.0",
     "concurrently": "5.1.0",
     "css-loader": "3.5.0",
-    "electron": "10.1.6",
+    "electron": "11.1.1",
     "electron-builder": "22.7.0",
     "electron-react-devtools": "0.5.3",
     "eslint": "6.5.1",


### PR DESCRIPTION
Since Electron 10.1.6 i18n is broken on macOS and app.getLocale()
always return en_US, see https://github.com/electron/electron/issues/26612

Updating Electron to 11.1.1 fixes the issue and app.getLocale() again
returns the proper values.