### PR TITLE
Add enable remote control to settings panel

### DIFF
--- a/app/features/conference/components/Conference.js
+++ b/app/features/conference/components/Conference.js
@@ -15,7 +15,6 @@ import { conferenceEnded, conferenceJoined } from '../actions';
 import JitsiMeetExternalAPI from '../external_api';
 import { LoadingIndicator, Wrapper } from '../styled';
 
-const ENABLE_REMOTE_CONTROL = false;
 
 type Props = {
 
@@ -63,6 +62,11 @@ type Props = {
      * Start with Video Muted.
      */
     _startWithVideoMuted: boolean;
+
+    /**
+     * Enable Remote Control.
+     */
+    _enableRemoteControl: boolean;
 };
 
 type State = {
@@ -212,7 +216,8 @@ class Conference extends Component<Props, State> {
 
         const configOverwrite = {
             startWithAudioMuted: this.props._startWithAudioMuted,
-            startWithVideoMuted: this.props._startWithVideoMuted
+            startWithVideoMuted: this.props._startWithVideoMuted,
+            enableRemoteControl: this.props._enableRemoteControl
         };
 
         const options = {
@@ -250,8 +255,7 @@ class Conference extends Component<Props, State> {
         const iframe = this._api.getIFrame();
 
         setupScreenSharingRender(this._api);
-
-        if (ENABLE_REMOTE_CONTROL) {
+        if (this.props._enableRemoteControl) {
             new RemoteControl(iframe); // eslint-disable-line no-new
         }
 
@@ -408,7 +412,8 @@ function _mapStateToProps(state: Object) {
         _serverURL: state.settings.serverURL,
         _serverTimeout: state.settings.serverTimeout,
         _startWithAudioMuted: state.settings.startWithAudioMuted,
-        _startWithVideoMuted: state.settings.startWithVideoMuted
+        _startWithVideoMuted: state.settings.startWithVideoMuted,
+        _enableRemoteControl: state.settings.enableRemoteControl
     };
 }
 

--- a/app/features/settings/actionTypes.js
+++ b/app/features/settings/actionTypes.js
@@ -68,3 +68,14 @@ export const SET_SERVER_TIMEOUT = Symbol('SET_SERVER_TIMEOUT');
  * }
  */
 export const SET_VIDEO_MUTED = Symbol('SET_VIDEO_MUTED');
+
+/**
+ * The type of (redux) action that sets Remote Control Enabled.
+ *
+ * @type {
+ *     type: SET_ENABLE_REMOTE_CONTROL,
+ *     enableRemoteControl: boolean
+ * }
+ */
+
+export const SET_ENABLE_REMOTE_CONTROL = Symbol('SET_ENABLE_REMOTE_CONTROL');

--- a/app/features/settings/actions.js
+++ b/app/features/settings/actions.js
@@ -7,7 +7,8 @@ import {
     SET_NAME,
     SET_SERVER_URL,
     SET_SERVER_TIMEOUT,
-    SET_VIDEO_MUTED
+    SET_VIDEO_MUTED,
+    SET_ENABLE_REMOTE_CONTROL
 } from './actionTypes';
 
 import { normalizeServerURL } from '../utils';
@@ -108,6 +109,21 @@ export function setStartWithVideoMuted(startWithVideoMuted: boolean) {
     };
 }
 
+/**
+ * Set Enable Remote Control.
+ *
+ * @param {boolean} enableRemoteControl - Whether to enable remote control
+ * @returns {{
+ *     type: SET_ENABLE_REMOTE_CONTROL,
+ *     enableRemoteControl: boolean
+ * }}
+ */
+export function setEnableRemoteControl(enableRemoteControl: boolean) {
+    return {
+        type: SET_ENABLE_REMOTE_CONTROL,
+        enableRemoteControl
+    };
+}
 
 /**
  * Set window always on top.

--- a/app/features/settings/components/SettingsDrawer.js
+++ b/app/features/settings/components/SettingsDrawer.js
@@ -17,7 +17,7 @@ import { Onboarding, advenaceSettingsSteps, startOnboarding } from '../../onboar
 import { Form, SettingsContainer, TogglesContainer } from '../styled';
 import {
     setEmail, setName, setWindowAlwaysOnTop,
-    setStartWithAudioMuted, setStartWithVideoMuted
+    setStartWithAudioMuted, setStartWithVideoMuted, setEnableRemoteControl
 } from '../actions';
 
 import SettingToggle from './SettingToggle';
@@ -144,6 +144,10 @@ class SettingsDrawer extends Component<Props, *> {
                                     label = { t('settings.startWithVideoMuted') }
                                     settingChangeEvent = { setStartWithVideoMuted }
                                     settingName = 'startWithVideoMuted' />
+                                <SettingToggle
+                                    label = { t('settings.enableRemoteControl') }
+                                    settingChangeEvent = { setEnableRemoteControl }
+                                    settingName = 'enableRemoteControl' />
                             </SpotlightTarget>
                         </TogglesContainer>
                         <Panel

--- a/app/features/settings/reducer.js
+++ b/app/features/settings/reducer.js
@@ -7,7 +7,8 @@ import {
     SET_NAME,
     SET_SERVER_URL,
     SET_SERVER_TIMEOUT,
-    SET_VIDEO_MUTED
+    SET_VIDEO_MUTED,
+    SET_ENABLE_REMOTE_CONTROL
 } from './actionTypes';
 
 type State = {
@@ -17,7 +18,8 @@ type State = {
     serverURL: ?string,
     serverTimeout: ?number,
     startWithAudioMuted: boolean,
-    startWithVideoMuted: boolean
+    startWithVideoMuted: boolean,
+    enableRemoteControl: boolean
 };
 
 const username = window.jitsiNodeAPI.osUserInfo().username;
@@ -29,6 +31,7 @@ const DEFAULT_STATE = {
     serverURL: undefined,
     serverTimeout: undefined,
     startWithAudioMuted: false,
+    enableRemoteControl: false,
     startWithVideoMuted: false
 };
 
@@ -81,6 +84,12 @@ export default (state: State = DEFAULT_STATE, action: Object) => {
         return {
             ...state,
             startWithVideoMuted: action.startWithVideoMuted
+        };
+
+    case SET_ENABLE_REMOTE_CONTROL:
+        return {
+            ...state,
+            enableRemoteControl: action.enableRemoteControl
         };
 
     default:

--- a/app/i18n/lang/de.json
+++ b/app/i18n/lang/de.json
@@ -31,6 +31,7 @@
 		"alwaysOnTopWindow": "Immer im Vordergrund",
 		"startWithAudioMuted": "Ohne Audio starten",
 		"startWithVideoMuted": "Ohne Video starten",
+		"enableRemoteControl": "Steuerung übernehmen aktivieren",
 		"invalidServer": "Falsche Server-Adresse",
 		"invalidServerTimeout": "Üngültiger Wert für die Server-Wartezeit",
 		"serverUrl": "Server-Adresse",

--- a/app/i18n/lang/en.json
+++ b/app/i18n/lang/en.json
@@ -31,6 +31,7 @@
 		"alwaysOnTopWindow": "Always on Top Window",
 		"startWithAudioMuted": "Start with Audio muted",
 		"startWithVideoMuted": "Start with Video muted",
+		"enableRemoteControl": "Enable remote control",
 		"invalidServer": "Invalid Server URL",
 		"invalidServerTimeout": "Invalid value for Server Timeout",
 		"serverUrl": "Server URL",

--- a/app/i18n/lang/fr.json
+++ b/app/i18n/lang/fr.json
@@ -31,6 +31,7 @@
     "alwaysOnTopWindow": "Fenêtre Toujours au Dessus",
     "startWithAudioMuted": "Démarrer avec le micro coupé",
     "startWithVideoMuted": "Démarrer avec la caméra coupée",
+    "enableRemoteControl": "activer la télécommande",
     "invalidServer": "URL invalide",
     "serverUrl": "URL du serveur",
     "serverTimeout": "Délai de connexion au server (en secondes)"

--- a/app/i18n/lang/it.json
+++ b/app/i18n/lang/it.json
@@ -31,6 +31,7 @@
 		"alwaysOnTopWindow": "Finestra sempre in primo piano",
 		"startWithAudioMuted": "Inizia senza audio",
 		"startWithVideoMuted": "Inizio senza video",
+		"enableRemoteControl": "Attiva le funzioni dell’ID del telecomando",
 		"invalidServer": "URL del server errato",
 		"serverUrl": "URL Server",
         "serverTimeout": "Timeout del server (in secondi)"


### PR DESCRIPTION
enable remote control is disabled by default. 

if you run your own instance of jitsi, then the remote control can be enabled in my opinion.  

Perhaps it could be protected a little bit more by checking, that the default server is overriden. 
