### PR TITLE
Enhancements to make it Mac App Store (mas) compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,17 @@
       "hardenedRuntime": true,
       "entitlements": "entitlements.mac.plist",
       "entitlementsInherit": "entitlements.mac.plist",
+      "asarUnpack": "**/*.node",
       "extendInfo": {
         "NSCameraUsageDescription": "Jitsi Meet requires access to your camera in order to make video-calls.",
-        "NSMicrophoneUsageDescription": "Jitsi Meet requires access to your microphone in order to make calls (audio/video)."
+        "NSMicrophoneUsageDescription": "Jitsi Meet requires access to your microphone in order to make calls (audio/video).",
+        "LSMultipleInstancesProhibited": true
       }
+    },
+    "mas": {
+      "entitlements": "resources/entitlements.mas.plist",
+      "entitlementsInherit": "resources/entitlements.mas.inherit.plist",
+      "hardenedRuntime": false
     },
     "linux": {
       "artifactName": "jitsi-meet-${arch}.${ext}",

--- a/resources/entitlements.mas.inherit.plist
+++ b/resources/entitlements.mas.inherit.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.inherit</key>
+    <true/>
+</dict>
+</plist>

--- a/resources/entitlements.mas.plist
+++ b/resources/entitlements.mas.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.microphone</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
- disable the autoupdater if running as mas (was not working anyway, just logging an error on every start)
- replace check via app.requestSingleInstanceLock() with LSMultipleInstancesProhibited in Info.plist
  due to https://github.com/electron/electron/issues/15958
- Ignore certificate-error as otherwise every network connection (eg. Jitsi URL in iframe) is cancelled
- Quit the app also when all windows are closed to conform to macOS Human Interface Guidelines
  Comments from review:
  If the application is a single-window app, it might be appropriate to save data and quit the app when the main window is closed.
- "asarUnpack": "**/*.node" to also sign the native addons when packaging
- add the required mas-specific entitlements which include the app-sandbox key

Signed-off-by: Christoph Settgast <csett86@web.de>