### PR TITLE
Update Electron to 12.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7920,9 +7920,9 @@
       }
     },
     "electron": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.0.tgz",
-      "integrity": "sha512-p6oxZ4LG82hopPGAsIMOjyoL49fr6cexyFNH0kADA9Yf+mJ72DN7bjvBG+6V7r6QKhwYgsSsW8RpxBeVOUbxVQ==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.1.tgz",
+      "integrity": "sha512-4bTfLSTmuFkMxq3RMyjd8DxuzbxI1Bde879XDrBA4kFWbKhZ3hfXqHXQz3129eCmcLre5odcNsWq7/xzyJilMA==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -7931,9 +7931,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.14.31",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
-          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
+          "version": "14.14.33",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.33.tgz",
+          "integrity": "sha512-oJqcTrgPUF29oUP8AsUqbXGJNuPutsetaa9kTQAQce5Lx5dTYWV02ScBiT/k1BX/Z7pKeqedmvp39Wu4zR7N7g==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "babel-loader": "8.1.0",
     "concurrently": "5.1.0",
     "css-loader": "3.5.0",
-    "electron": "12.0.0",
+    "electron": "12.0.1",
     "electron-builder": "22.10.5",
     "electron-react-devtools": "0.5.3",
     "eslint": "6.5.1",


### PR DESCRIPTION
Several fixes and patch-updated bundled Chromium.
For details see https://github.com/electron/electron/releases/tag/v12.0.1

Signed-off-by: Christoph Settgast <csett86@web.de>