### PR TITLE
README: explain why remote control was disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Desktop application for [Jitsi Meet] built with [Electron].
 - [End-to-End Encryption](https://jitsi.org/blog/e2ee/) support (BETA)
 - Works with any Jitsi Meet deployment
 - Builtin auto-updates
-- ~Remote control~ (currently disabled)
+- ~Remote control~ (currently [disabled](https://github.com/jitsi/jitsi-meet-electron/issues/483) due to [security issues](https://github.com/jitsi/security-advisories/blob/master/advisories/JSA-2020-0001.md))
 - Always-On-Top window
 - Support for deeplinks such as `jitsi-meet://myroom` (will open `myroom` on the configured Jitsi instance) or `jitsi-meet://jitsi.mycompany.com/myroom` (will open `myroom` on the Jitsi instance running on `jitsi.mycompany.com`)
 


### PR DESCRIPTION
Just marking the remote control feature as disabled without explaining why was not at all helpful to end users needing this feature.  So link to a couple of pages to help them understand the reasoning.  It may even attract developers to work on a fix.