### PR TITLE
Update openExternalLink.js

### DIFF
--- a/app/features/utils/openExternalLink.js
+++ b/app/features/utils/openExternalLink.js
@@ -2,7 +2,7 @@ const { shell } = require('electron');
 const url = require('url');
 
 
-const protocolRegex = /^https?:/i;
+const protocolRegex = /^(https|mailto)?:/i;
 
 /**
  * Opens the given link in an external browser.

--- a/app/features/utils/openExternalLink.js
+++ b/app/features/utils/openExternalLink.js
@@ -2,7 +2,7 @@ const { shell } = require('electron');
 const url = require('url');
 
 
-const protocolRegex = /^(https|mailto)?:/i;
+const protocolRegex = /^(https?|mailto):/i;
 
 /**
  * Opens the given link in an external browser.


### PR DESCRIPTION
Change RegEx so you can open the 'mailto' link used by the button 'Your Default Email'