### PR TITLE
Update Electron to 12.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6040,9 +6040,9 @@
       "dev": true
     },
     "boolean": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.2.tgz",
-      "integrity": "sha512-RwywHlpCRc3/Wh81MiCKun4ydaIFyW5Ea6JbL6sRCVx5q5irDw7pMXBUFYF/jArQ6YrG36q0kpovc9P/Kd3I4g==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.3.tgz",
+      "integrity": "sha512-EqrTKXQX6Z3A2nRmMEIlAIfjQOgFnVO2nqZGpbcsPnYGWBwpFqzlrozU1dy+S2iqfYDLh26ef4KrgTxu9xQrxA==",
       "dev": true,
       "optional": true
     },
@@ -7981,9 +7981,9 @@
       }
     },
     "electron": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.2.tgz",
-      "integrity": "sha512-14luh9mGzfL4e0sncyy0+kW37IU7Y0Y1tvI97FDRSW0ZBQxi5cmAwSs5dmPmNBFBIGtzkaGaEB01j9RjZuCmow==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.3.tgz",
+      "integrity": "sha512-vPrvdBa8wkeo0IEjOOc5GgYpseEeeceT5N1uDTOh/OVkObt4WfsECFhU/AuHzejkgivSULoHrlyvVsFOLbP7Ew==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -7992,9 +7992,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.14.35",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
-          "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
+          "version": "14.14.37",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
+          "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
           "dev": true
         }
       }
@@ -9810,9 +9810,9 @@
       }
     },
     "global-agent": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.12.tgz",
-      "integrity": "sha512-caAljRMS/qcDo69X9BfkgrihGUgGx44Fb4QQToNQjsiWh+YlQ66uqYVAdA8Olqit+5Ng0nkz09je3ZzANMZcjg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.2.0.tgz",
+      "integrity": "sha512-+20KpaW6DDLqhG7JDiJpD1JvNvb8ts+TNl7BPOYcURqCrXqnN1Vf+XVOrkKJAFPqfX+oEhsdzOj1hLWkBTdNJg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -9826,9 +9826,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
-          "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.1.tgz",
+          "integrity": "sha512-pwCxEXnj27XG47mu7SXAwhLP3L5CrlvCB91ANUkIz40P27kUcvNfSdvyZJ9CLHiVoKSp+TTChMQMSKQEH/IQxA==",
           "dev": true,
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "babel-loader": "8.1.0",
     "concurrently": "5.1.0",
     "css-loader": "3.5.0",
-    "electron": "12.0.2",
+    "electron": "12.0.3",
     "electron-builder": "22.10.5",
     "electron-react-devtools": "0.5.3",
     "eslint": "6.5.1",


### PR DESCRIPTION
Several fixes and patch-updated bundled Chromium.
For details see https://github.com/electron/electron/releases/tag/v12.0.3

Signed-off-by: Christoph Settgast <csett86@web.de>