### PR TITLE
Update Electron to 12.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7981,9 +7981,9 @@
       }
     },
     "electron": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.3.tgz",
-      "integrity": "sha512-vPrvdBa8wkeo0IEjOOc5GgYpseEeeceT5N1uDTOh/OVkObt4WfsECFhU/AuHzejkgivSULoHrlyvVsFOLbP7Ew==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.4.tgz",
+      "integrity": "sha512-A8Lq3YMZ1CaO1z5z5nsyFxIwkgwXLHUwL2pf9MVUHpq7fv3XUewCMD98EnLL3DdtiyCvw5KMkeT1WGsZh8qFug==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "babel-loader": "8.1.0",
     "concurrently": "5.1.0",
     "css-loader": "3.5.0",
-    "electron": "12.0.3",
+    "electron": "12.0.4",
     "electron-builder": "22.10.5",
     "electron-react-devtools": "0.5.3",
     "eslint": "6.5.1",


### PR DESCRIPTION
Security: backported fix for chromium:1196683. https://github.com/electron/electron/pull/28638

Signed-off-by: Christoph Settgast <csett86@web.de>