### PR TITLE
fix(mas) WebRTC UDP connections

### DIFF
--- a/resources/entitlements.mas.plist
+++ b/resources/entitlements.mas.plist
@@ -6,6 +6,8 @@
     <true/>
     <key>com.apple.security.network.client</key>
     <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
     <key>com.apple.security.device.camera</key>
     <true/>
     <key>com.apple.security.device.audio-input</key>


### PR DESCRIPTION
UDP connections (for WebRTC) require both the server and the client entitlement,
as an app with only the client entitlement enabled can send, but not receive, data.

See https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_network_client

Signed-off-by: Christoph Settgast <csett86@web.de>