### PR TITLE
feat(linux): enable PipeWire support for screensharing

### DIFF
--- a/main.js
+++ b/main.js
@@ -37,6 +37,9 @@ app.commandLine.appendSwitch('disable-features', 'IOSurfaceCapturer');
 // Enable Opus RED field trial.
 app.commandLine.appendSwitch('force-fieldtrials', 'WebRTC-Audio-Red-For-Opus/Enabled/');
 
+// Enable optional PipeWire support.
+app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer');
+
 // Needed until robot.js is fixed: https://github.com/octalmage/robotjs/issues/580
 app.allowRendererProcessReuse = false;
 


### PR DESCRIPTION
This is required on wayland based desktops like Fedora 34 or
Ubuntu 21.04.

Closes: #567