### PR TITLE
fix(mac): remove wifi stats as they cause hangs every 10 seconds

### DIFF
--- a/app/features/conference/components/Conference.js
+++ b/app/features/conference/components/Conference.js
@@ -266,7 +266,11 @@ class Conference extends Component<Props, State> {
             setupAlwaysOnTopRender(this._api);
         }
 
-        setupWiFiStats(iframe);
+        // Disable WiFiStats on mac due to jitsi-meet-electron#585
+        if (window.jitsiNodeAPI.platform !== 'darwin') {
+            setupWiFiStats(iframe);
+        }
+
         setupPowerMonitorRender(this._api);
     }
 

--- a/app/preload/preload.js
+++ b/app/preload/preload.js
@@ -1,3 +1,5 @@
+/* global process */
+
 const createElectronStorage = require('redux-persist-electron-storage');
 const { ipcRenderer, remote } = require('electron');
 const os = require('os');
@@ -11,6 +13,7 @@ window.jitsiNodeAPI = {
     createElectronStorage,
     osUserInfo: os.userInfo,
     openExternalLink,
+    platform: process.platform,
     jitsiMeetElectronUtils,
     getLocale: remote.app.getLocale,
     ipc: {


### PR DESCRIPTION
The getWiFiStats causes screen freezes every 10 seconds for 2-4 seconds,
thus temporarily remove them.

Closes: #595