### PR TITLE
refactor: remove dependency to deprecated remote module

### DIFF
--- a/app/i18n/index.js
+++ b/app/i18n/index.js
@@ -16,7 +16,7 @@ const languages = {
     sq: { translation: require('./lang/sq.json') }
 };
 
-const detectedLocale = window.jitsiNodeAPI.getLocale();
+const detectedLocale = navigator.language;
 
 i18n
     .use(initReactI18next)

--- a/app/preload/preload.js
+++ b/app/preload/preload.js
@@ -1,5 +1,5 @@
 const createElectronStorage = require('redux-persist-electron-storage');
-const { ipcRenderer, remote } = require('electron');
+const { ipcRenderer } = require('electron');
 const os = require('os');
 const jitsiMeetElectronUtils = require('jitsi-meet-electron-utils');
 const { openExternalLink } = require('../features/utils/openExternalLink');
@@ -12,7 +12,6 @@ window.jitsiNodeAPI = {
     osUserInfo: os.userInfo,
     openExternalLink,
     jitsiMeetElectronUtils,
-    getLocale: remote.app.getLocale,
     ipc: {
         on: (channel, listener) => {
             if (!whitelistedIpcChannels.includes(channel)) {


### PR DESCRIPTION
the remote module will be removed from electron 14 onwards,
so replace the locale detection with native browser api that
is available in the renderer.

Signed-off-by: Christoph Settgast <csett86@web.de>