### PR TITLE
chore(deps): update electron to 12.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6020,9 +6020,9 @@
       "dev": true
     },
     "boolean": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.0.tgz",
-      "integrity": "sha512-K6r5tvO1ykeYerI7jIyTvSFw2l6D6DzqkljGj2E2uyYAAdDo2SV4qGJIV75cHIQpTFyb6BB0BEHiDdDrFsNI+g==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.2.tgz",
+      "integrity": "sha512-YN6UmV0FfLlBVvRvNPx3pz5W/mUoYB24J4WSXOKP/OOJpi+Oq6WYqPaNTHzjI0QzwWtnvEd5CGYyQPgp1jFxnw==",
       "dev": true,
       "optional": true
     },
@@ -7928,9 +7928,9 @@
       }
     },
     "electron": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.10.tgz",
-      "integrity": "sha512-qaNvFG4AgeuT3PkSljQ9MlY7hz87wIwJ5cmSZ1453IVsUd0BV7pcaLViSpR1bRSqxetDDWxCLtCp0N9RXeDZww==",
+      "version": "12.0.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.11.tgz",
+      "integrity": "sha512-6gPjcce3QCeAWZ8UVAqVy6os+86D5BcxgkIzlROxX89u+du/i7WpZXF5F1vgv419rspds9OHejP3JrJnoUGh6w==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -7939,9 +7939,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.2.tgz",
-          "integrity": "sha512-sld7b/xmFum66AAKuz/rp/CUO8+98fMpyQ3SBfzzBNGMd/1iHBTAg9oyAvcYlAj46bpc74r91jSw2iFdnx29nw==",
+          "version": "14.17.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
+          "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==",
           "dev": true
         }
       }
@@ -9767,9 +9767,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.13.1.tgz",
-          "integrity": "sha512-JqveUc4igkqwStL2RTRn/EPFGBOfEZHxJl/8ej1mXJR75V3go2mFF4bmUYkEIT1rveHKnkUlcJX/c+f1TyIovQ==",
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.14.0.tgz",
+          "integrity": "sha512-3s+ed8er9ahK+zJpp9ZtuVcDoFzHNiZsPbNAAE4KXgrRHbjSqqNN6xGSXq6bq7TZIbKj4NLrLb6bJ5i+vSVjHA==",
           "dev": true,
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "babel-loader": "8.1.0",
     "concurrently": "5.1.0",
     "css-loader": "3.5.0",
-    "electron": "12.0.10",
+    "electron": "12.0.11",
     "electron-builder": "22.10.5",
     "electron-react-devtools": "0.5.3",
     "eslint": "6.5.1",


### PR DESCRIPTION
Fixes a memory leak when requesting files in ASAR archive from renderer

For all details, see https://github.com/electron/electron/releases/tag/v12.0.11

Signed-off-by: Christoph Settgast <csett86@web.de>