### PR TITLE
fix(deb): match dependencies with ldd from electron 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,16 @@
         }
       ]
     },
+    "deb": {
+      "depends": [
+        "libgtk-3-0",
+        "libnss3",
+        "libxtst6",
+        "xdg-utils",
+        "libatspi2.0-0",
+        "libuuid1"
+      ]
+    },
     "win": {
       "artifactName": "jitsi-meet.${ext}",
       "target": [


### PR DESCRIPTION
The previously mentioned default fpm dependencies did not match
what electron 12 really depends on (via ldd).

This also fixes dependencies that are no longer existing on Debian 11.

Closes: #596
Signed-off-by: Christoph Settgast <csett86@web.de>