### PR TITLE
chore(deps): update electron to 12.0.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8064,9 +8064,9 @@
       }
     },
     "electron": {
-      "version": "12.0.12",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.12.tgz",
-      "integrity": "sha512-6E6dyjuJcGpgJPnsWY7dp1Xhha/NPigNDhxlmdKPwvso8DntFGrGt0SPhi1/wfaWZsXW5wqHBGIP4IN2cZ75WQ==",
+      "version": "12.0.13",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.13.tgz",
+      "integrity": "sha512-2yx102mhqgyaTVH+GCet4hURKOIuI27DcVdlval5T3eOEZMOHNrCbi8/8PZ7MqMfB5PIxJ+grS5S00/n5Zcu2Q==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -9943,9 +9943,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.15.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.1.tgz",
-          "integrity": "sha512-h8VbZYnc9pDzueiS2610IULDkpFFPunHwIpl8yRwFahAEEdSpHlTy3h3z3rKq5h11CaUdBEeRViu9AYvbxiMeg==",
+          "version": "3.15.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
+          "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q==",
           "dev": true,
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "babel-loader": "8.1.0",
     "concurrently": "5.1.0",
     "css-loader": "3.5.0",
-    "electron": "12.0.12",
+    "electron": "12.0.13",
     "electron-builder": "22.10.5",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Security fixes for bundled chromium

For all details see https://github.com/electron/electron/releases/tag/v12.0.13

Signed-off-by: Christoph Settgast <csett86@web.de>