### PR TITLE
chore(deps): update electron to 13.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8064,9 +8064,9 @@
       }
     },
     "electron": {
-      "version": "12.0.13",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.13.tgz",
-      "integrity": "sha512-2yx102mhqgyaTVH+GCet4hURKOIuI27DcVdlval5T3eOEZMOHNrCbi8/8PZ7MqMfB5PIxJ+grS5S00/n5Zcu2Q==",
+      "version": "13.1.7",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-13.1.7.tgz",
+      "integrity": "sha512-sVfpP/0s6a82FK32LMuEe9L+aWZw15u3uYn9xUJArPjy4OZHteE6yM5871YCNXNiDnoCLQ5eqQWipiVgHsf8nQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -8075,9 +8075,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.4.tgz",
-          "integrity": "sha512-8kQ3+wKGRNN0ghtEn7EGps/B8CzuBz1nXZEIGGLP2GnwbqYn4dbTs7k+VKLTq1HvZLRCIDtN3Snx1Ege8B7L5A==",
+          "version": "14.17.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.5.tgz",
+          "integrity": "sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA==",
           "dev": true
         }
       }
@@ -10965,12 +10965,12 @@
       }
     },
     "jitsi-meet-electron-utils": {
-      "version": "github:jitsi/jitsi-meet-electron-utils#75d935cc2641791e39c49301cb4cc8b1519efafe",
-      "from": "github:jitsi/jitsi-meet-electron-utils#v2.0.16",
+      "version": "github:jitsi/jitsi-meet-electron-utils#92298631f52bf5465a0266307b1f608753584eb4",
+      "from": "github:jitsi/jitsi-meet-electron-utils#v2.0.22",
       "requires": {
         "jitsi-meet-logger": "github:jitsi/jitsi-meet-logger#v1.0.0",
-        "mac-screen-capture-permissions": "github:saghul/mac-screen-capture-permissions#14568eba35b0eebcf2b1b5c40d2c35fec3d88e89",
-        "nan": "^2.14.0",
+        "mac-screen-capture-permissions": "^2.0.0",
+        "nan": "^2.14.2",
         "postis": "^2.2.0",
         "prebuild-install": "^5.3.0",
         "robotjs": "0.6.0"
@@ -11313,8 +11313,9 @@
       }
     },
     "mac-screen-capture-permissions": {
-      "version": "github:saghul/mac-screen-capture-permissions#14568eba35b0eebcf2b1b5c40d2c35fec3d88e89",
-      "from": "github:saghul/mac-screen-capture-permissions#14568eba35b0eebcf2b1b5c40d2c35fec3d88e89",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mac-screen-capture-permissions/-/mac-screen-capture-permissions-2.0.0.tgz",
+      "integrity": "sha512-f70KKpx5WhD8mmrAwLeeee31EfSM4p1K7kBBNBVXyfWE7ZQTIbbAF2PxJ0bMsDxyyeX5roBcH+qJYlSTANtCOA==",
       "requires": {
         "electron-util": "^0.13.0",
         "execa": "^2.0.4",
@@ -11847,9 +11848,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   "dependencies": {
     "electron-debug": "^3.2.0",
     "electron-reload": "^1.5.0",
-    "jitsi-meet-electron-utils": "github:jitsi/jitsi-meet-electron-utils#v2.0.16"
+    "jitsi-meet-electron-utils": "github:jitsi/jitsi-meet-electron-utils#v2.0.22"
   },
   "devDependencies": {
     "@atlaskit/button": "^10.1.3",
@@ -155,7 +155,7 @@
     "babel-loader": "8.1.0",
     "concurrently": "5.1.0",
     "css-loader": "3.5.0",
-    "electron": "12.0.13",
+    "electron": "13.1.7",
     "electron-builder": "22.10.5",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Updates chromium from 89 to 91, updates linked pipewire 0.2 -> 0.3.

For all details, see https://github.com/electron/electron/releases/tag/v13.1.17

Afterwards manually update nan for all dependencies to @latest so that eg. robotjs
compiles with electron 13.

Signed-off-by: Christoph Settgast <csett86@web.de>