### PR TITLE
2.8.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jitsi-meet-electron",
-  "version": "2.8.9",
+  "version": "2.8.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jitsi-meet-electron",
-  "version": "2.8.9",
+  "version": "2.8.10",
   "description": "Electron application for Jitsi Meet",
   "main": "./build/main.js",
   "productName": "Jitsi Meet",


### PR DESCRIPTION
bf251d2 chore(deps): update electron to 13.1.9
4176370 chore(deps): bump path-parse from 1.0.6 to 1.0.7
625b8b8 Enable WebAssemblyCSP flag so wasm-eval CSP can be used instead of requiring unsafe-eval