### PR TITLE
chore(deps): update electron to 13.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3518,9 +3518,9 @@
       }
     },
     "@electron/get": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.12.4.tgz",
-      "integrity": "sha512-6nr9DbJPUR9Xujw6zD3y+rS95TyItEVM0NVjt1EehY2vUWfIgPiIPVHxCvaTS0xr2B+DRxovYVKbuOWqC35kjg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.13.0.tgz",
+      "integrity": "sha512-+SjZhRuRo+STTO1Fdhzqnv9D2ZhjxXP6egsJ9kiO8dtP68cDx7dFCwWi64dlMQV7sWcfW1OYCW4wviEBzmRsfQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -6125,9 +6125,9 @@
       "dev": true
     },
     "boolean": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.2.tgz",
-      "integrity": "sha512-YN6UmV0FfLlBVvRvNPx3pz5W/mUoYB24J4WSXOKP/OOJpi+Oq6WYqPaNTHzjI0QzwWtnvEd5CGYyQPgp1jFxnw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.4.tgz",
+      "integrity": "sha512-3hx0kwU3uzG6ReQ3pnaFQPSktpBw6RHN3/ivDKEuU8g1XSfafowyvDnadjv1xp8IZqhtSukxlwv9bF6FhX8m0w==",
       "dev": true,
       "optional": true
     },
@@ -8064,9 +8064,9 @@
       }
     },
     "electron": {
-      "version": "13.1.9",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-13.1.9.tgz",
-      "integrity": "sha512-By4Zb72XNQLrPb70BXdIW3NtEHFwybP5DIQjohnCxOYONq5vojuHjNcTuWnBgMvwQ2qwykk6Tw5EwF2Pt0CWjA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-13.2.1.tgz",
+      "integrity": "sha512-/K0Uw+o3+phbHtrVL6qDFVJqmeRF6EIPwVeUHEH5R8JNy13f4X3RouKjQzVyY/Os8fEqYHGFONWhD6q6g750HQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -8075,9 +8075,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.9.tgz",
-          "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g==",
+          "version": "14.17.11",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.11.tgz",
+          "integrity": "sha512-n2OQ+0Bz6WEsUjrvcHD1xZ8K+Kgo4cn9/w94s1bJS690QMUWfJPW/m7CCb7gPkA1fcYwL2UpjXP/rq/Eo41m6w==",
           "dev": true
         }
       }
@@ -9943,9 +9943,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.16.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.1.tgz",
-          "integrity": "sha512-AAkP8i35EbefU+JddyWi12AWE9f2N/qr/pwnDtWz4nyUIBGMJPX99ANFFRSw6FefM374lDujdtLDyhN2A/btHw==",
+          "version": "3.16.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.2.tgz",
+          "integrity": "sha512-P0KPukO6OjMpjBtHSceAZEWlDD1M2Cpzpg6dBbrjFqFhBHe/BwhxaP820xKOjRn/lZRQirrCusIpLS/n2sgXLQ==",
           "dev": true,
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "babel-loader": "8.1.0",
     "concurrently": "5.1.0",
     "css-loader": "3.5.0",
-    "electron": "13.1.9",
+    "electron": "13.2.1",
     "electron-builder": "22.10.5",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Mostly chromium security updates, for all details
see https://github.com/electron/electron/releases/tag/v13.2.1

Signed-off-by: Christoph Settgast <csett86@web.de>