### PR TITLE
chore(deps): update electron to 13.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8064,9 +8064,9 @@
       }
     },
     "electron": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-13.2.1.tgz",
-      "integrity": "sha512-/K0Uw+o3+phbHtrVL6qDFVJqmeRF6EIPwVeUHEH5R8JNy13f4X3RouKjQzVyY/Os8fEqYHGFONWhD6q6g750HQ==",
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-13.2.3.tgz",
+      "integrity": "sha512-FzWhbKHjq7ZTpPQFaYiLPL64erC8/BOsu5NlNN9nQ6f7rIP8ygKlNAlQit3vbOcksQAwItDUCIw4sW0mcaRpCA==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -8075,9 +8075,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.11",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.11.tgz",
-          "integrity": "sha512-n2OQ+0Bz6WEsUjrvcHD1xZ8K+Kgo4cn9/w94s1bJS690QMUWfJPW/m7CCb7gPkA1fcYwL2UpjXP/rq/Eo41m6w==",
+          "version": "14.17.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.12.tgz",
+          "integrity": "sha512-vhUqgjJR1qxwTWV5Ps5txuy2XMdf7Fw+OrdChRboy8BmWUPkckOhphaohzFG6b8DW7CrxaBMdrdJ47SYFq1okw==",
           "dev": true
         }
       }
@@ -9943,9 +9943,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.16.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.2.tgz",
-          "integrity": "sha512-P0KPukO6OjMpjBtHSceAZEWlDD1M2Cpzpg6dBbrjFqFhBHe/BwhxaP820xKOjRn/lZRQirrCusIpLS/n2sgXLQ==",
+          "version": "3.16.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
+          "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
           "dev": true,
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "babel-loader": "8.1.0",
     "concurrently": "5.1.0",
     "css-loader": "3.5.0",
-    "electron": "13.2.1",
+    "electron": "13.2.3",
     "electron-builder": "22.10.5",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Mostly chromium security updates, for all details
see https://github.com/electron/electron/releases/tag/v13.2.2 and
https://github.com/electron/electron/releases/tag/v13.2.3

Signed-off-by: Christoph Settgast <csett86@web.de>