### PR TITLE
chore(deps): update electron to 13.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8064,9 +8064,9 @@
       }
     },
     "electron": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-13.2.3.tgz",
-      "integrity": "sha512-FzWhbKHjq7ZTpPQFaYiLPL64erC8/BOsu5NlNN9nQ6f7rIP8ygKlNAlQit3vbOcksQAwItDUCIw4sW0mcaRpCA==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-13.3.0.tgz",
+      "integrity": "sha512-d/BvOLDjI4i7yf9tqCuLL2fFGA2TrM/D9PyRpua+rJolG0qrwp/FohP02L0m+44kmPpofIo4l3NPwLmzyKKimA==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -8075,9 +8075,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.12",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.12.tgz",
-          "integrity": "sha512-vhUqgjJR1qxwTWV5Ps5txuy2XMdf7Fw+OrdChRboy8BmWUPkckOhphaohzFG6b8DW7CrxaBMdrdJ47SYFq1okw==",
+          "version": "14.17.15",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.15.tgz",
+          "integrity": "sha512-D1sdW0EcSCmNdLKBGMYb38YsHUS6JcM7yQ6sLQ9KuZ35ck7LYCKE7kYFHOO59ayFOY3zobWVZxf4KXhYHcHYFA==",
           "dev": true
         }
       }
@@ -9943,9 +9943,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.16.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-          "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+          "version": "3.17.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.2.tgz",
+          "integrity": "sha512-XkbXqhcXeMHPRk2ItS+zQYliAMilea2euoMsnpRRdDad6b2VY6CQQcwz1K8AnWesfw4p165RzY0bTnr3UrbYiA==",
           "dev": true,
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "babel-loader": "8.1.0",
     "concurrently": "5.1.0",
     "css-loader": "3.5.0",
-    "electron": "13.2.3",
+    "electron": "13.3.0",
     "electron-builder": "22.10.5",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Mostly chromium security updates, for all details
see https://github.com/electron/electron/releases/tag/v13.3.0

Signed-off-by: Christoph Settgast <csett86@web.de>