### PR TITLE
chore(deps): update electron to 13.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8064,9 +8064,9 @@
       }
     },
     "electron": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-13.3.0.tgz",
-      "integrity": "sha512-d/BvOLDjI4i7yf9tqCuLL2fFGA2TrM/D9PyRpua+rJolG0qrwp/FohP02L0m+44kmPpofIo4l3NPwLmzyKKimA==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-13.4.0.tgz",
+      "integrity": "sha512-KJGWS2qa0xZXIMPMDUNkRVO8/JxRd4+M0ejYYOzu2LIQ5ijecPzNuNR9nvDkml9XyyRBzu975FkhJcwD17ietQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -9943,9 +9943,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.17.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.2.tgz",
-          "integrity": "sha512-XkbXqhcXeMHPRk2ItS+zQYliAMilea2euoMsnpRRdDad6b2VY6CQQcwz1K8AnWesfw4p165RzY0bTnr3UrbYiA==",
+          "version": "3.17.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
+          "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==",
           "dev": true,
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "babel-loader": "8.1.0",
     "concurrently": "5.1.0",
     "css-loader": "3.5.0",
-    "electron": "13.3.0",
+    "electron": "13.4.0",
     "electron-builder": "22.10.5",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Mostly chromium security updates, for all details
see https://github.com/electron/electron/releases/tag/v13.4.0

Signed-off-by: Christoph Settgast <csett86@web.de>