### PR TITLE
Switch to local storage and migrate old settings

### DIFF
--- a/app/features/redux/store.js
+++ b/app/features/redux/store.js
@@ -1,14 +1,38 @@
 // @flow
 
 import { createStore } from 'redux';
-import { persistReducer } from 'redux-persist';
+import { persistReducer, getStoredState } from 'redux-persist';
+import storage from 'redux-persist/lib/storage'; // uses localStorage
 
 import middleware from './middleware';
 import reducers from './reducers';
 
+const migrateFromElectronStore = async state => {
+    // migrate to local storage by checking if state is undefined
+    // (first launch or first launch after switch to local storage)
+    // and previous electron-store config.json exists.
+    if (state === undefined && window.jitsiNodeAPI.electronStoreExists) {
+        const electronStoreState = await getStoredState({
+            key: 'root',
+            storage: window.jitsiNodeAPI.createElectronStorage(),
+            debug: true
+        });
+
+        if ('onboarding' in electronStoreState) {
+            return electronStoreState;
+        }
+    }
+
+    return state;
+};
+
 const persistConfig = {
     key: 'root',
-    storage: window.jitsiNodeAPI.createElectronStorage(),
+
+    // remove this and all electron-store-related dependencies end of 2021
+    // (3 months migration period from electron-store to local storage)
+    migrate: migrateFromElectronStore,
+    storage,
     whitelist: [
         'onboarding',
         'recentList',

--- a/app/preload/preload.js
+++ b/app/preload/preload.js
@@ -15,6 +15,7 @@ window.jitsiNodeAPI = {
     openExternalLink,
     platform: process.platform,
     jitsiMeetElectronUtils,
+    electronStoreExists: ipcRenderer.sendSync('electron-store-exists'),
     ipc: {
         on: (channel, listener) => {
             if (!whitelistedIpcChannels.includes(channel)) {

--- a/main.js
+++ b/main.js
@@ -396,3 +396,7 @@ ipcMain.on('renderer-ready', () => {
             .send('protocol-data-msg', protocolDataForFrontApp);
     }
 });
+
+ipcMain.on('electron-store-exists', event => {
+    event.returnValue = existsSync(path.join(app.getPath('userData'), 'config.json'));
+});


### PR DESCRIPTION
This is a preparation for electron 14+, where electron-store is no longer
in a usable state (currently used version does not work due to remote module
removed in electron 14, latest version extends every app startup to 10 seconds).

Once sufficient migration period has passed, electron-store and
redux-persist-electron-storage and the ipc call introduced here
(electron-store-exists) can be removed.

This replaces #635