### PR TITLE
chore(deps): update electron to 13.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8034,9 +8034,9 @@
       }
     },
     "electron": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-13.4.0.tgz",
-      "integrity": "sha512-KJGWS2qa0xZXIMPMDUNkRVO8/JxRd4+M0ejYYOzu2LIQ5ijecPzNuNR9nvDkml9XyyRBzu975FkhJcwD17ietQ==",
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-13.5.2.tgz",
+      "integrity": "sha512-CPakwDpy5m8dL0383F5uJboQcVtn9bT/+6/wdDKo8LuTUO9aER1TF41v7feZgZW2c+UwoGPWa814ElSQ3qta2A==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -8045,9 +8045,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.15.tgz",
-          "integrity": "sha512-D1sdW0EcSCmNdLKBGMYb38YsHUS6JcM7yQ6sLQ9KuZ35ck7LYCKE7kYFHOO59ayFOY3zobWVZxf4KXhYHcHYFA==",
+          "version": "14.17.27",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.27.tgz",
+          "integrity": "sha512-94+Ahf9IcaDuJTle/2b+wzvjmutxXAEXU6O81JHblYXUg2BDG+dnBy7VxIPHKAyEEDHzCMQydTJuWvrE+Aanzw==",
           "dev": true
         }
       }
@@ -9896,9 +9896,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.17.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
-          "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==",
+          "version": "3.18.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.3.tgz",
+          "integrity": "sha512-tReEhtMReZaPFVw7dajMx0vlsz3oOb8ajgPoHVYGxr8ErnZ6PcYEvvmjGmXlfpnxpkYSdOQttjB+MvVbCGfvLw==",
           "dev": true,
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "babel-loader": "8.1.0",
     "concurrently": "5.1.0",
     "css-loader": "3.5.0",
-    "electron": "13.4.0",
+    "electron": "13.5.2",
     "electron-builder": "22.11.11",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Mostly chromium security updates, for all details
see https://github.com/electron/electron/releases/tag/v13.5.0,
https://github.com/electron/electron/releases/tag/v13.5.1,
https://github.com/electron/electron/releases/tag/v13.5.2

Signed-off-by: Christoph Settgast <csett86@web.de>