### PR TITLE
mac: allow notarize with API key

### DIFF
--- a/notarize.js
+++ b/notarize.js
@@ -9,20 +9,34 @@ exports.default = async function notarizing(context) {
         return;
     }
 
-    if (!(process.env.APPLE_ID && process.env.APPLE_ID_PASSWORD && process.env.TEAM_ID)) {
-        console.log('Skipping notarization');
-
-        return;
-    }
-
     const appName = context.packager.appInfo.productFilename;
+    const appPath = `${appOutDir}/${appName}.app`;
 
-    return await notarize({
-        tool: 'notarytool',
-        appBundleId: pkgJson.build.appId,
-        appPath: `${appOutDir}/${appName}.app`,
-        appleId: process.env.APPLE_ID,
-        appleIdPassword: process.env.APPLE_ID_PASSWORD,
-        teamId: process.env.TEAM_ID
-    });
+    if (process.env.APPLE_ID && process.env.APPLE_ID_PASSWORD && process.env.TEAM_ID) {
+        console.log(`Notarizing ${appPath} with user & password`);
+
+        return await notarize({
+            tool: 'notarytool',
+            appBundleId: pkgJson.build.appId,
+            appPath,
+            appleId: process.env.APPLE_ID,
+            appleIdPassword: process.env.APPLE_ID_PASSWORD,
+            teamId: process.env.TEAM_ID
+        });
+    } else if (process.env.API_KEY_FILE && process.env.API_KEY_ID && process.env.API_KEY_ISSUER_ID) {
+        console.log(`Notarizing ${appPath} with API key`);
+
+        return await notarize({
+            tool: 'notarytool',
+            appBundleId: pkgJson.build.appId,
+            appPath,
+            appleApiKey: process.env.API_KEY_FILE,
+            appleApiKeyId: process.env.API_KEY_ID,
+            appleApiIssuer: process.env.API_KEY_ISSUER_ID
+        });
+    }
+    console.log('Skipping notarization');
+
+    return;
+
 };


### PR DESCRIPTION
Use eg in GH actions like this with

secret API_KEY = API key file as coming from Apple
secret API_KEY_ID = API key ID as coming from Apple
secret API_KEY_ISSUER_ID = API key issuer ID as coming from Apple

    mkdir -p ~/private_keys/
    echo '${{ secrets.api_key }}' > ~/private_keys/AuthKey_${{ secrets.api_key_id }}.p8
    echo "API_KEY_FILE=~/private_keys/AuthKey_${{ secrets.api_key_id }}.p8" >> $GITHUB_ENV
    echo "API_KEY_ID=${{ secrets.api_key_id }}" >> $GITHUB_ENV
    echo "API_KEY_ISSUER_ID=${{ secrets.api_key_issuer_id }}" >> $GITHUB_ENV
