### PR TITLE
cleanup: remove unused mac electron/universal workaround

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,7 +24,6 @@ const URL = require('url');
 const config = require('./app/features/config');
 const { openExternalLink } = require('./app/features/utils/openExternalLink');
 const pkgJson = require('./package.json');
-const { existsSync } = require('fs');
 
 const showDevTools = Boolean(process.env.SHOW_DEV_TOOLS) || (process.argv.indexOf('--show-dev-tools') > -1);
 
@@ -181,18 +180,7 @@ function createJitsiMeetWindow() {
     });
 
     // Path to root directory.
-    let basePath = isDev ? __dirname : app.getAppPath();
-
-    // runtime detection on mac if this is a universal build with app-arm64.asar'
-    // as prepared in https://github.com/electron/universal/blob/master/src/index.ts
-    // if universal build, load the arch-specific real asar as the app does not load otherwise
-    if (process.platform === 'darwin' && existsSync(path.join(app.getAppPath(), '..', 'app-arm64.asar'))) {
-        if (process.arch === 'arm64') {
-            basePath = app.getAppPath().replace('app.asar', 'app-arm64.asar');
-        } else if (process.arch === 'x64') {
-            basePath = app.getAppPath().replace('app.asar', 'app-x64.asar');
-        }
-    }
+    const basePath = isDev ? __dirname : app.getAppPath();
 
     // URL for index.html which will be our entry point.
     const indexURL = URL.format({


### PR DESCRIPTION
Since d383521 the binaries are universal itself, so app.asar is no
longer split by electron/universal. Thus remove the now unnecessary
workaround.
