### PR TITLE
cleanup: insertable streams and wasm SIMD are on by default

### DIFF
--- a/main.js
+++ b/main.js
@@ -203,8 +203,7 @@ function createJitsiMeetWindow() {
         minHeight: 600,
         show: false,
         webPreferences: {
-            enableBlinkFeatures: 'RTCInsertableStreams,WebAssemblySimd,WebAssemblyCSP',
-            enableRemoteModule: true,
+            enableBlinkFeatures: 'WebAssemblyCSP',
             contextIsolation: false,
             nativeWindowOpen: true,
             nodeIntegration: false,


### PR DESCRIPTION
insertable streams since M86 according to https://chromestatus.com/feature/6321945865879552
wasm SIMD since M91 according to https://chromestatus.com/feature/6533147810332672
remote module is no longer used/present, thus remove that noop enable as well
