### PR TITLE
chore(deps): update electron to 16.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "babel-loader": "8.1.0",
         "concurrently": "5.1.0",
         "css-loader": "3.5.0",
-        "electron": "16.0.4",
+        "electron": "16.0.6",
         "electron-builder": "22.11.11",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -9191,9 +9191,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.4.tgz",
-      "integrity": "sha512-IptwmowvMP1SFOmZLh6rrURwfnOxbDBXBRBcaOdfBM5I+B9mgtdNwzNC3ymFFNzEkZUwdOyg9fu3iyjAAQIQgw==",
+      "version": "16.0.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.6.tgz",
+      "integrity": "sha512-Xs9dYLYhcJf3wXn8m2gDqFTb1L862KEhMxOx9swfFBHj6NoUPPtUgw/RyPQ0tXN1XPxG9vnBkoI0BdcKwrLKuQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -17905,26 +17905,34 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -17932,13 +17940,17 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -17946,57 +17958,75 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -18006,21 +18036,27 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -18034,8 +18070,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -18053,13 +18091,17 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -18069,16 +18111,20 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -18086,21 +18132,27 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -18110,13 +18162,17 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -18126,13 +18182,17 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/minimist": {
       "version": "1.2.5",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -18140,8 +18200,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
@@ -18149,8 +18211,10 @@
     "node_modules/watchpack/node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.3",
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -18160,13 +18224,17 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/needle": {
       "version": "2.3.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -18181,8 +18249,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -18201,8 +18271,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -18213,21 +18285,27 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.8",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1",
@@ -18236,8 +18314,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -18247,48 +18327,60 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -18296,21 +18388,27 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
+      "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -18323,8 +18421,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.7",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -18337,8 +18437,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -18348,49 +18450,65 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -18402,8 +18520,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -18413,16 +18533,20 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -18438,26 +18562,34 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/glob-parent": {
       "version": "3.1.0",
@@ -26851,9 +26983,9 @@
       }
     },
     "electron": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.4.tgz",
-      "integrity": "sha512-IptwmowvMP1SFOmZLh6rrURwfnOxbDBXBRBcaOdfBM5I+B9mgtdNwzNC3ymFFNzEkZUwdOyg9fu3iyjAAQIQgw==",
+      "version": "16.0.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.6.tgz",
+      "integrity": "sha512-Xs9dYLYhcJf3wXn8m2gDqFTb1L862KEhMxOx9swfFBHj6NoUPPtUgw/RyPQ0tXN1XPxG9vnBkoI0BdcKwrLKuQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.13.0",
@@ -33950,19 +34082,27 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -33970,11 +34110,15 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -33982,57 +34126,81 @@
             },
             "chownr": {
               "version": "1.1.4",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "debug": {
               "version": "3.2.6",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "^2.1.1"
               }
             },
             "deep-extend": {
               "version": "0.6.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "fs-minipass": {
               "version": "1.2.7",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minipass": "^2.6.0"
               }
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "gauge": {
               "version": "2.7.4",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -34047,6 +34215,8 @@
             "glob": {
               "version": "7.1.6",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -34058,11 +34228,15 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
               }
@@ -34070,6 +34244,8 @@
             "ignore-walk": {
               "version": "3.0.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minimatch": "^3.0.4"
               }
@@ -34077,6 +34253,8 @@
             "inflight": {
               "version": "1.0.6",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -34084,37 +34262,51 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -34123,6 +34315,8 @@
             "minizlib": {
               "version": "1.3.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minipass": "^2.9.0"
               }
@@ -34130,17 +34324,23 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
             },
             "ms": {
               "version": "2.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "needle": {
               "version": "2.3.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "debug": "^3.2.6",
                 "iconv-lite": "^0.4.4",
@@ -34150,6 +34350,8 @@
             "node-pre-gyp": {
               "version": "0.14.0",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "detect-libc": "^1.0.2",
                 "mkdirp": "^0.5.1",
@@ -34166,6 +34368,8 @@
             "nopt": {
               "version": "4.0.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "abbrev": "1",
                 "osenv": "^0.1.4"
@@ -34174,17 +34378,23 @@
             "npm-bundled": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "npm-normalize-package-bin": "^1.0.1"
               }
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "npm-packlist": {
               "version": "1.4.8",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ignore-walk": "^3.0.1",
                 "npm-bundled": "^1.0.1",
@@ -34194,6 +34404,8 @@
             "npmlog": {
               "version": "4.1.2",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -34203,30 +34415,42 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "osenv": {
               "version": "0.1.5",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.0"
@@ -34234,15 +34458,21 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "rc": {
               "version": "1.2.8",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -34253,6 +34483,8 @@
             "readable-stream": {
               "version": "2.3.7",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -34266,37 +34498,53 @@
             "rimraf": {
               "version": "2.7.1",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "glob": "^7.1.3"
               }
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "semver": {
               "version": "5.7.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -34304,6 +34552,8 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -34313,17 +34563,23 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "tar": {
               "version": "4.4.13",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "chownr": "^1.1.1",
                 "fs-minipass": "^1.2.5",
@@ -34336,22 +34592,30 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "string-width": "^1.0.2 || 2"
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "babel-loader": "8.1.0",
     "concurrently": "5.1.0",
     "css-loader": "3.5.0",
-    "electron": "16.0.4",
+    "electron": "16.0.6",
     "electron-builder": "22.11.11",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Contains updated Chromium to 96.0.4664.110

For all details see https://github.com/electron/electron/releases/tag/v16.0.5
and https://github.com/electron/electron/releases/tag/v16.0.6

Signed-off-by: Christoph Settgast <csett86@web.de>
