### PR TITLE
ci(mac): directly set env vars based on secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,17 +40,14 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '16'
-    - name: Prepare for app signing and notarization
-      if: ${{ github.event_name != 'pull_request' }}
-      run: |
-        echo "CSC_LINK=${{ secrets.mac_cert }}" >> $GITHUB_ENV
-        echo "CSC_KEY_PASSWORD=${{ secrets.mac_cert_password }}" >> $GITHUB_ENV
-        echo "APPLE_ID=${{ secrets.apple_id }}" >> $GITHUB_ENV
-        echo "APPLE_ID_PASSWORD=${{ secrets.apple_id_password }}" >> $GITHUB_ENV
-        echo "TEAM_ID=${{ secrets.team_id }}" >> $GITHUB_ENV
     - name: Build it
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CSC_LINK: ${{ secrets.mac_cert }}
+        CSC_KEY_PASSWORD: ${{ secrets.mac_cert_password }}
+        APPLE_ID: ${{ secrets.apple_id }}
+        APPLE_ID_PASSWORD: ${{ secrets.apple_id_password }}
+        TEAM_ID: ${{ secrets.team_id }}
       run: |
         npm install
         npm run lint


### PR DESCRIPTION
Then they are only set to something meaningful if they are present,
so same logic as before, just a bit cleaner and better working for downstream
forks which dont need mac signed builds.