### PR TITLE
feat: allow the jitsi-meet:// protocol in the URL box

### DIFF
--- a/app/features/conference/components/Conference.js
+++ b/app/features/conference/components/Conference.js
@@ -171,7 +171,7 @@ class Conference extends Component<Props, State> {
         const appProtocolSurplus = `${config.appProtocolPrefix}://`;
 
         // replace the custom url with https, otherwise new URL() raises 'Invalid URL'.
-        if (this._conference.serverURL.indexOf(appProtocolSurplus) === 0) {
+        if (this._conference.serverURL.startsWith(appProtocolSurplus)) {
             this._conference.serverURL = this._conference.serverURL.replace(appProtocolSurplus, 'https://');
         }
         const url = new URL(this._conference.room, this._conference.serverURL);

--- a/app/features/conference/components/Conference.js
+++ b/app/features/conference/components/Conference.js
@@ -168,6 +168,12 @@ class Conference extends Component<Props, State> {
      * @returns {void}
      */
     _loadConference() {
+        const appProtocolSurplus = `${config.appProtocolPrefix}://`;
+
+        // replace the custom url with https, otherwise new URL() raises 'Invalid URL'.
+        if (this._conference.serverURL.indexOf(appProtocolSurplus) === 0) {
+            this._conference.serverURL = this._conference.serverURL.replace(appProtocolSurplus, 'https://');
+        }
         const url = new URL(this._conference.room, this._conference.serverURL);
         const roomName = url.pathname.split('/').pop();
         const host = this._conference.serverURL.replace(/https?:\/\//, '');


### PR DESCRIPTION
Allow this so that when you send around links to the app and someone
accidentally copy-pastes them into the URL box, things dont break.
