### PR TITLE
ci: switch to clean-install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        npm install
+        npm ci
         npm run dist
     - uses: actions/upload-artifact@v2
       with:
@@ -54,7 +54,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        npm install
+        npm ci
         npm run lint
         npm run dist
     - uses: actions/upload-artifact@v2
@@ -76,7 +76,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        npm install
+        npm ci
         npm run dist
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Detects if package-lock.json is no longer in sync with package.json and
ensures that build is reproducible by only relying on package-lock.json
