### PR TITLE
chore(deps): update electron to 17.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "babel-loader": "8.1.0",
         "concurrently": "5.1.0",
         "css-loader": "3.5.0",
-        "electron": "17.0.1",
+        "electron": "^17.1.2",
         "electron-builder": "22.11.11",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -9015,9 +9015,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-17.0.1.tgz",
-      "integrity": "sha512-CBReR/QEOpgwMdt59lWCtj9wC8oHB6aAjMF1lhXcGew132xtp+C5N6EaXb/fmDceVYLouziYjbNcpeXsWrqdpA==",
+      "version": "17.1.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-17.1.2.tgz",
+      "integrity": "sha512-hqKQaUIRWX5Y2eAD8FZINWD/e5TKdpkbBYbkcZmJS4Bd1PKQsaDVc9h5xoA8zZQkPymE9rss+swjRpAFurOPGQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -26542,9 +26542,9 @@
       }
     },
     "electron": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-17.0.1.tgz",
-      "integrity": "sha512-CBReR/QEOpgwMdt59lWCtj9wC8oHB6aAjMF1lhXcGew132xtp+C5N6EaXb/fmDceVYLouziYjbNcpeXsWrqdpA==",
+      "version": "17.1.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-17.1.2.tgz",
+      "integrity": "sha512-hqKQaUIRWX5Y2eAD8FZINWD/e5TKdpkbBYbkcZmJS4Bd1PKQsaDVc9h5xoA8zZQkPymE9rss+swjRpAFurOPGQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "babel-loader": "8.1.0",
     "concurrently": "5.1.0",
     "css-loader": "3.5.0",
-    "electron": "17.0.1",
+    "electron": "17.1.2",
     "electron-builder": "22.11.11",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Mostly chromium security updates, for all details
see https://github.com/electron/electron/releases/tag/v17.1.1 and
https://github.com/electron/electron/releases/tag/v17.1.2

Signed-off-by: Christoph Settgast <csett86@web.de>
