### PR TITLE
feat(preload) limit the exposed SDK API surface

### DIFF
--- a/app/features/conference/components/Conference.js
+++ b/app/features/conference/components/Conference.js
@@ -234,35 +234,11 @@ class Conference extends Component<Props, State> {
             }
         );
 
-        const { RemoteControl,
-            setupScreenSharingRender,
-            setupAlwaysOnTopRender,
-            initPopupsConfigurationRender,
-            setupWiFiStats,
-            setupPowerMonitorRender
-        } = window.jitsiNodeAPI.jitsiMeetElectronUtils;
-
-        initPopupsConfigurationRender(this._api);
-
-        const iframe = this._api.getIFrame();
-
-        setupScreenSharingRender(this._api);
-
-        if (ENABLE_REMOTE_CONTROL) {
-            new RemoteControl(iframe); // eslint-disable-line no-new
-        }
-
-        // Allow window to be on top if enabled in settings
-        if (this.props._alwaysOnTopWindowEnabled) {
-            setupAlwaysOnTopRender(this._api);
-        }
-
-        // Disable WiFiStats on mac due to jitsi-meet-electron#585
-        if (window.jitsiNodeAPI.platform !== 'darwin') {
-            setupWiFiStats(iframe);
-        }
-
-        setupPowerMonitorRender(this._api);
+        // Setup Jitsi Meet Electron SDK on this renderer.
+        window.jitsiNodeAPI.setupRenderer(this._api, {
+            enableRemoteControl: ENABLE_REMOTE_CONTROL,
+            enableAlwaysOnTopWindow: this.props._alwaysOnTopWindowEnabled
+        });
     }
 
     /**

--- a/app/preload/preload.js
+++ b/app/preload/preload.js
@@ -1,16 +1,52 @@
 /* global process */
 
 const { ipcRenderer } = require('electron');
-const jitsiMeetElectronUtils = require('@jitsi/electron-sdk');
+const { RemoteControl,
+    setupScreenSharingRender,
+    setupAlwaysOnTopRender,
+    initPopupsConfigurationRender,
+    setupWiFiStats,
+    setupPowerMonitorRender
+} = require('@jitsi/electron-sdk');
 const { openExternalLink } = require('../features/utils/openExternalLink');
 
-
+const platform = process.platform;
 const whitelistedIpcChannels = [ 'protocol-data-msg', 'renderer-ready' ];
+
+/**
+ * Setup the renderer process.
+ *
+ * @param {*} api - API object.
+ * @param {*} options - Options for what to enable.
+ * @returns {void}
+ */
+function setupRenderer(api, options = {}) {
+    initPopupsConfigurationRender(api);
+
+    const iframe = api.getIFrame();
+
+    setupScreenSharingRender(api);
+
+    if (options.enableRemoteControl) {
+        new RemoteControl(iframe); // eslint-disable-line no-new
+    }
+
+    // Allow window to be on top if enabled in settings
+    if (options.enableAlwaysOnTopWindow) {
+        setupAlwaysOnTopRender(api);
+    }
+
+    // Disable WiFiStats on mac due to jitsi-meet-electron#585
+    if (platform !== 'darwin') {
+        setupWiFiStats(iframe);
+    }
+
+    setupPowerMonitorRender(api);
+}
 
 window.jitsiNodeAPI = {
     openExternalLink,
-    platform: process.platform,
-    jitsiMeetElectronUtils,
+    setupRenderer,
     ipc: {
         on: (channel, listener) => {
             if (!whitelistedIpcChannels.includes(channel)) {


### PR DESCRIPTION
Expose a single function that sets up everything on the renderer.