### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/app/features/app/components/App.js
+++ b/app/features/app/components/App.js
@@ -69,8 +69,8 @@ class App extends Component<*> {
      */
     _listenOnProtocolMessages(event, inputURL: string) {
         // Remove trailing slash if one exists.
-        if (inputURL.substr(-1) === '/') {
-            inputURL = inputURL.substr(0, inputURL.length - 1); // eslint-disable-line no-param-reassign
+        if (inputURL.slice(-1) === '/') {
+            inputURL = inputURL.slice(0, -1); // eslint-disable-line no-param-reassign
         }
 
         const conference = createConferenceObjectFromURL(inputURL);

--- a/app/features/welcome/components/Welcome.js
+++ b/app/features/welcome/components/Welcome.js
@@ -162,7 +162,7 @@ class Welcome extends Component<Props, State> {
      */
     _animateRoomnameChanging(word: string) {
         let animateTimeoutId;
-        const roomPlaceholder = this.state.roomPlaceholder + word.substr(0, 1);
+        const roomPlaceholder = this.state.roomPlaceholder + word.slice(0, 1);
 
         if (word.length > 1) {
             animateTimeoutId


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.