### PR TITLE
chore: remove unused alias for process in webpack.main config

### DIFF
--- a/webpack.main.js
+++ b/webpack.main.js
@@ -19,10 +19,7 @@ module.exports = {
     resolve: {
         modules: [
             path.resolve('./node_modules')
-        ],
-        alias: {
-            process: 'process/browser'
-        }
+        ]
     }
 };
 


### PR DESCRIPTION
process is available in the electron-main target, no need to alias
