### PR TITLE
chore(deps): update electron to 17.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "babel-loader": "^8.2.3",
         "concurrently": "5.1.0",
         "css-loader": "^6.7.1",
-        "electron": "17.1.2",
+        "electron": "17.4.1",
         "electron-builder": "22.11.11",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -6301,9 +6301,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-17.1.2.tgz",
-      "integrity": "sha512-hqKQaUIRWX5Y2eAD8FZINWD/e5TKdpkbBYbkcZmJS4Bd1PKQsaDVc9h5xoA8zZQkPymE9rss+swjRpAFurOPGQ==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-17.4.1.tgz",
+      "integrity": "sha512-0qX+DbiNXlVSUxXq4lWVTis8QYqC4Q7R/Xkk3YZQbHMXZ90bWilypC3gBZAcN4MQD4AYUIebphBOpRPxlXY3nQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -19500,9 +19500,9 @@
       }
     },
     "electron": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-17.1.2.tgz",
-      "integrity": "sha512-hqKQaUIRWX5Y2eAD8FZINWD/e5TKdpkbBYbkcZmJS4Bd1PKQsaDVc9h5xoA8zZQkPymE9rss+swjRpAFurOPGQ==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-17.4.1.tgz",
+      "integrity": "sha512-0qX+DbiNXlVSUxXq4lWVTis8QYqC4Q7R/Xkk3YZQbHMXZ90bWilypC3gBZAcN4MQD4AYUIebphBOpRPxlXY3nQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "babel-loader": "^8.2.3",
     "concurrently": "5.1.0",
     "css-loader": "^6.7.1",
-    "electron": "17.1.2",
+    "electron": "17.4.1",
     "electron-builder": "22.11.11",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Mostly chromium security updates, and not yet updating to electron 18 as that requires at least electron-builder 23.0.4 (due to https://github.com/electron-userland/electron-builder/pull/6750), but electron-builder 23.0.4+ are not yet stable.

Signed-off-by: Christoph Settgast <csett86@web.de>
