### PR TITLE
chore(deps): update electron to 19.0.6

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,10 +40,6 @@ app.commandLine.appendSwitch('disable-features', 'IOSurfaceCapturer');
 // Enable Opus RED field trial.
 app.commandLine.appendSwitch('force-fieldtrials', 'WebRTC-Audio-Red-For-Opus/Enabled/');
 
-// Allow deprecated plan-b with electron 17.0.0. We'll need to address:
-// https://community.jitsi.org/t/switch-to-unified-plan-on-chrome/98322
-app.commandLine.appendSwitch('disable-features', 'RTCDisallowPlanBOutsideDeprecationTrial');
-
 // Enable optional PipeWire support.
 if (!app.commandLine.hasSwitch('enable-features')) {
     app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer');

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "babel-loader": "^8.2.3",
         "concurrently": "5.1.0",
         "css-loader": "^6.7.1",
-        "electron": "17.4.1",
+        "electron": "19.0.6",
         "electron-builder": "23.1.0",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -3568,9 +3568,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
-      "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==",
+      "version": "16.11.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.41.tgz",
+      "integrity": "sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -6365,14 +6365,14 @@
       }
     },
     "node_modules/electron": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-17.4.1.tgz",
-      "integrity": "sha512-0qX+DbiNXlVSUxXq4lWVTis8QYqC4Q7R/Xkk3YZQbHMXZ90bWilypC3gBZAcN4MQD4AYUIebphBOpRPxlXY3nQ==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.6.tgz",
+      "integrity": "sha512-S9Yud32nKhB0iWC0lGl2JXz4FQnCiLCnP5Vehm1/CqyeICcQGmgQaZl2HYpCJ2pesKIsYL9nsgmku/10cxm/gg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@electron/get": "^1.13.0",
-        "@types/node": "^14.6.2",
+        "@electron/get": "^1.14.1",
+        "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
       },
       "bin": {
@@ -17535,9 +17535,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
-      "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==",
+      "version": "16.11.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.41.tgz",
+      "integrity": "sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ==",
       "dev": true
     },
     "@types/parse-json": {
@@ -19738,13 +19738,13 @@
       }
     },
     "electron": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-17.4.1.tgz",
-      "integrity": "sha512-0qX+DbiNXlVSUxXq4lWVTis8QYqC4Q7R/Xkk3YZQbHMXZ90bWilypC3gBZAcN4MQD4AYUIebphBOpRPxlXY3nQ==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.6.tgz",
+      "integrity": "sha512-S9Yud32nKhB0iWC0lGl2JXz4FQnCiLCnP5Vehm1/CqyeICcQGmgQaZl2HYpCJ2pesKIsYL9nsgmku/10cxm/gg==",
       "dev": true,
       "requires": {
-        "@electron/get": "^1.13.0",
-        "@types/node": "^14.6.2",
+        "@electron/get": "^1.14.1",
+        "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "babel-loader": "^8.2.3",
     "concurrently": "5.1.0",
     "css-loader": "^6.7.1",
-    "electron": "17.4.1",
+    "electron": "19.0.6",
     "electron-builder": "23.1.0",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Contains Chromium 98 -> 102 update, for high level overview see

https://www.electronjs.org/blog/electron-18-0
https://www.electronjs.org/blog/electron-19-0

Plan B support is now removed as well, as chromium 102 no longer offers
it: https://chromestatus.com/feature/5823036655665152

Signed-off-by: Christoph Settgast <csett86@web.de>
