### PR TITLE
chore(deps): update electron to 19.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "babel-loader": "^8.2.3",
         "concurrently": "5.1.0",
         "css-loader": "^6.7.1",
-        "electron": "19.0.6",
+        "electron": "19.0.8",
         "electron-builder": "23.1.0",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -6370,9 +6370,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "19.0.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.6.tgz",
-      "integrity": "sha512-S9Yud32nKhB0iWC0lGl2JXz4FQnCiLCnP5Vehm1/CqyeICcQGmgQaZl2HYpCJ2pesKIsYL9nsgmku/10cxm/gg==",
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.8.tgz",
+      "integrity": "sha512-OWK3P/NbDFfBUv+wbYv1/OV4jehY5DQPT7n1maQJfN9hsnrWTMktXS/bmS05eSUAjNAzHmKPKfiKH2c1Yr7nGw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -19750,9 +19750,9 @@
       }
     },
     "electron": {
-      "version": "19.0.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.6.tgz",
-      "integrity": "sha512-S9Yud32nKhB0iWC0lGl2JXz4FQnCiLCnP5Vehm1/CqyeICcQGmgQaZl2HYpCJ2pesKIsYL9nsgmku/10cxm/gg==",
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.8.tgz",
+      "integrity": "sha512-OWK3P/NbDFfBUv+wbYv1/OV4jehY5DQPT7n1maQJfN9hsnrWTMktXS/bmS05eSUAjNAzHmKPKfiKH2c1Yr7nGw==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.14.1",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "babel-loader": "^8.2.3",
     "concurrently": "5.1.0",
     "css-loader": "^6.7.1",
-    "electron": "19.0.6",
+    "electron": "19.0.8",
     "electron-builder": "23.1.0",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Security Patches from contained Chromium

See https://github.com/electron/electron/releases/tag/v19.0.7
and https://github.com/electron/electron/releases/tag/v19.0.8
