### PR TITLE
WIP: ensure only prebuilds are used on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
     - name: Build it
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PREBUILDS_ONLY: 1
       run: |
         npm ci
         npm run dist


### PR DESCRIPTION
Maybe due to https://github.com/prebuild/node-gyp-build/pull/46 messing with our CI on windows-2022