### PR TITLE
fix(ci): downgrade to windows-2019 for node-gyp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           dist/latest-mac.yml
   build-windows:
     name: Windows
-    runs-on: windows-2022
+    runs-on: windows-2019
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3


### PR DESCRIPTION
The node-gyp bundled with node 16 does not yet support windows-2022.
Downgrade ci to windows-2019 for now.

For details see eg. https://github.com/newrelic/node-native-metrics/issues/182
and other projects like https://github.com/prebuild/prebuildify/commit/c6e4368f02b1c1965aec3b1f5564a8e15c239ba5
