### PR TITLE
Backport parseURLParams from jitsi-meet

### DIFF
--- a/app/features/conference/components/Conference.js
+++ b/app/features/conference/components/Conference.js
@@ -10,6 +10,7 @@ import { push } from 'react-router-redux';
 import i18n from '../../../i18n';
 import config from '../../config';
 import { getSetting } from '../../settings';
+import { parseURLParams } from '../../utils/parseURLParams';
 
 import { conferenceEnded, conferenceJoined } from '../actions';
 import JitsiMeetExternalAPI from '../external_api';
@@ -178,14 +179,7 @@ class Conference extends Component<Props, State> {
         const roomName = url.pathname.split('/').pop();
         const host = this._conference.serverURL.replace(/https?:\/\//, '');
         const searchParameters = Object.fromEntries(url.searchParams);
-        const hashParameters = url.hash.substring(1).split('&')
-            .reduce((res, item) => {
-                const parts = item.split('=');
-
-                res[parts[0]] = parts[1];
-
-                return res;
-            }, {});
+        const hashParameters = parseURLParams(url);
 
         const locale = { lng: i18n.language };
         const urlParameters = {

--- a/app/features/utils/parseURLParams.js
+++ b/app/features/utils/parseURLParams.js
@@ -1,0 +1,83 @@
+import Bourne from '@hapi/bourne';
+
+/**
+ * Prints the error and reports it to the global error handler.
+ *
+ * @param {Error} e - The error object.
+ * @param {string} msg - A custom message to print in addition to the error.
+ * @returns {void}
+ */
+export function reportError(e, msg = '') {
+    console.error(msg, e);
+    window.onerror && window.onerror(msg, undefined, undefined, undefined, e);
+}
+
+
+/**
+ * A list if keys to ignore when parsing.
+ *
+ * @type {string[]}
+ */
+const blacklist = [ '__proto__', 'constructor', 'prototype' ];
+
+/**
+ * Parses the query/search or fragment/hash parameters out of a specific URL and
+ * returns them as a JS object.
+ *
+ * @param {URL} url - The URL to parse.
+ * @param {boolean} dontParse - If falsy, some transformations (for parsing the
+ * value as JSON) will be executed.
+ * @param {string} source - If {@code 'search'}, the parameters will parsed out
+ * of {@code url.search}; otherwise, out of {@code url.hash}.
+ * @returns {Object}
+ */
+export function parseURLParams(
+        url,
+        dontParse = false,
+        source = 'hash') {
+    if (typeof url === 'string') {
+        // eslint-disable-next-line no-param-reassign
+        url = new URL(url);
+    }
+    const paramStr = source === 'search' ? url.search : url.hash;
+    const params = {};
+    const paramParts = (paramStr && paramStr.substring(1).split('&')) || [];
+
+    // Detect and ignore hash params for hash routers.
+    if (source === 'hash' && paramParts.length === 1) {
+        const firstParam = paramParts[0];
+
+        if (firstParam.startsWith('/') && firstParam.split('&').length === 1) {
+            return params;
+        }
+    }
+
+    paramParts.forEach(part => {
+        const param = part.split('=');
+        const key = param[0];
+
+        if (!key || key.split('.').some(k => blacklist.includes(k))) {
+            return;
+        }
+
+        let value;
+
+        try {
+            value = param[1];
+
+            if (!dontParse) {
+                const decoded = decodeURIComponent(value).replace(/\\&/, '&');
+
+                value = decoded === 'undefined' ? undefined : Bourne.parse(decoded);
+            }
+        } catch (e) {
+            reportError(
+                e, `Failed to parse URL parameter value: ${String(value)}`);
+
+            return;
+        }
+        params[key] = value;
+    });
+
+    return params;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-flow": "^7.16.7",
         "@babel/preset-react": "^7.16.7",
+        "@hapi/bourne": "^3.0.0",
         "@jitsi/js-utils": "2.0.0",
         "@svgr/webpack": "^6.2.1",
         "babel-eslint": "10.0.3",
@@ -3054,6 +3055,12 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
       "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==",
+      "dev": true
+    },
+    "node_modules/@hapi/bourne": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
       "dev": true
     },
     "node_modules/@jitsi/electron-sdk": {
@@ -17206,6 +17213,12 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
       "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==",
+      "dev": true
+    },
+    "@hapi/bourne": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
       "dev": true
     },
     "@jitsi/electron-sdk": {

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-flow": "^7.16.7",
     "@babel/preset-react": "^7.16.7",
+    "@hapi/bourne": "^3.0.0",
     "@jitsi/js-utils": "2.0.0",
     "@svgr/webpack": "^6.2.1",
     "babel-eslint": "10.0.3",


### PR DESCRIPTION
Used https://github.com/jitsi/jitsi-meet/blob/master/react/features/base/util/parseURLParams.ts and removed the typescript stuff and replaced deprecated `substr()`
Ref: #642 

Signed-off-by: Christoph Wiechert <wio@psitrax.de>
CLA already signed

