### PR TITLE
fix(screensharing) add DesktopCaptureMacV2 to disabled-features

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,7 +35,7 @@ app.commandLine.appendSwitch('disable-site-isolation-trials');
 
 // This allows BrowserWindow.setContentProtection(true) to work on macOS.
 // https://github.com/electron/electron/issues/19880
-app.commandLine.appendSwitch('disable-features', 'IOSurfaceCapturer');
+app.commandLine.appendSwitch('disable-features', 'DesktopCaptureMacV2,IOSurfaceCapturer');
 
 // Enable Opus RED field trial.
 app.commandLine.appendSwitch('force-fieldtrials', 'WebRTC-Audio-Red-For-Opus/Enabled/');


### PR DESCRIPTION
This fixes the AoT and screensharing tracker from being captured based on https://github.com/electron/electron/issues/19880