### PR TITLE
feat: allow connecting to instances that set CSP and x-frame-options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,20 +37,6 @@ For *macOS* user, you can install the application using the following command:
 brew install --cask jitsi-meet
 ```
 
-### Using it with your own Jitsi Meet installation
-
-:warning: The following additional HTTP headers are known to break the Electron App:
-
-```
-Content-Security-Policy "frame-ancestors [looks like any value is bad]";
-X-Frame-Options "DENY";
-X-Frame-Options "sameorigin";
-```
-A working Content Security Policy looks like that:
-```
-Content-Security-Policy "img-src 'self' 'unsafe-inline' data:; script-src 'self' 'unsafe-inline' 'wasm-eval'; style-src 'self' 'unsafe-inline'; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none';";
-```
-
 ## Development
 
 If you want to hack on this project, here is how you do it.

--- a/main.js
+++ b/main.js
@@ -228,6 +228,17 @@ function createJitsiMeetWindow() {
 
     mainWindow.webContents.setWindowOpenHandler(windowOpenHandler);
 
+    // Filter out x-frame-options and CSP to allow loading jitsi via the iframe API
+    // Resolves https://github.com/jitsi/jitsi-meet-electron/issues/285
+    mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+        delete details.responseHeaders['x-frame-options'];
+        delete details.responseHeaders['content-security-policy'];
+
+        callback({
+            responseHeaders: details.responseHeaders
+        });
+    });
+
     initPopupsConfigurationMain(mainWindow);
     setupAlwaysOnTopMain(mainWindow, null, windowOpenHandler);
     setupPowerMonitorMain(mainWindow);

--- a/main.js
+++ b/main.js
@@ -232,7 +232,15 @@ function createJitsiMeetWindow() {
     // Resolves https://github.com/jitsi/jitsi-meet-electron/issues/285
     mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
         delete details.responseHeaders['x-frame-options'];
-        delete details.responseHeaders['content-security-policy'];
+
+        if (details.responseHeaders['content-security-policy']) {
+            const cspFiltered = details.responseHeaders['content-security-policy'][0]
+                .split(';')
+                .filter(x => x.indexOf('frame-ancestors') === -1)
+                .join(';');
+
+            details.responseHeaders['content-security-policy'] = [ cspFiltered ];
+        }
 
         callback({
             responseHeaders: details.responseHeaders

--- a/main.js
+++ b/main.js
@@ -228,7 +228,7 @@ function createJitsiMeetWindow() {
 
     mainWindow.webContents.setWindowOpenHandler(windowOpenHandler);
 
-    // Filter out x-frame-options and CSP to allow loading jitsi via the iframe API
+    // Filter out x-frame-options and frame-ancestors CSP to allow loading jitsi via the iframe API
     // Resolves https://github.com/jitsi/jitsi-meet-electron/issues/285
     mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
         delete details.responseHeaders['x-frame-options'];


### PR DESCRIPTION
While in browser environments the headers are sensible, the only purpose
of the electron app is load jitsi in the iframe api. Thus the security
implications are accepted to work with more jitsi instances.

Fixes: #285
