### PR TITLE
chore(deps) update electron to 21.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "babel-loader": "^8.2.3",
         "concurrently": "5.1.0",
         "css-loader": "^6.7.1",
-        "electron": "20.2.0",
+        "electron": "21.1.1",
         "electron-builder": "23.1.0",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -6376,9 +6376,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-20.2.0.tgz",
-      "integrity": "sha512-qw92PfXaC+fGoqJfQ2U5tVF8ux5HyVwgt1AxAtx6uz+dYcgtPBvfBN1jb+uzZVR+QVd+wCJ8Sqt6TD1ctwTauw==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-21.1.1.tgz",
+      "integrity": "sha512-EM2hvRJtiS3n54yx25Z0Qv54t3LGG+WjUHf1AOl+PKjQj+fmXnjIgVeIF9pM21kP1BTcyjrgvN6Sff0A45OB6A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -19722,9 +19722,9 @@
       }
     },
     "electron": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-20.2.0.tgz",
-      "integrity": "sha512-qw92PfXaC+fGoqJfQ2U5tVF8ux5HyVwgt1AxAtx6uz+dYcgtPBvfBN1jb+uzZVR+QVd+wCJ8Sqt6TD1ctwTauw==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-21.1.1.tgz",
+      "integrity": "sha512-EM2hvRJtiS3n54yx25Z0Qv54t3LGG+WjUHf1AOl+PKjQj+fmXnjIgVeIF9pM21kP1BTcyjrgvN6Sff0A45OB6A==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.14.1",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "babel-loader": "^8.2.3",
     "concurrently": "5.1.0",
     "css-loader": "^6.7.1",
-    "electron": "20.2.0",
+    "electron": "21.1.1",
     "electron-builder": "23.1.0",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Contains Chromium 104 -> 106 update and security updates of chromium since.
For details see https://www.electronjs.org/blog/electron-21-0
