### PR TITLE
Update README.md for Better Wayland Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,18 @@ To fix this, install libfuse2 as follows:
 sudo apt install libfuse2
 ```
 
-Under wayland, experimental native wayland support can be enabled with the command-line switch `--ozone-platform-hint` set to `auto`:
+Under wayland, **experimental** native wayland support can be enabled with the switches
 
 ```
-./jitsi-meet-x86_64.AppImage --ozone-platform-hint=auto
+--enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer --ozone-platform-hint=auto
 ```
 
-Note that screensharing is currently not supported under wayland, eg. the permissions prompt may loop endlessly.
+that is, from the command line run
+
+```
+./jitsi-meet-x86_64.AppImage --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer --ozone-platform-hint=auto
+```
+
 
 In case you experience a blank page after jitsi server upgrades, try removing the local cache files:
 


### PR DESCRIPTION
Hi all, 

so this is the first merge(?) request, I've ever made. So, not sure, that's how it works. 

Anyway.. I'm running jitsi-meet-electron from flathub. With the switches

```
--enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer --ozone-platform-hint=auto
```

I have 

* on GNOME the window decoration is presented 
![image](https://user-images.githubusercontent.com/36572014/203094697-fe1b68b2-ba8c-4f31-bbc7-75a689cc6b5a.png)

* functioning screen sharing, in particular GNOME's screen sharing dialog opens correctly. 
      - in view of the current electron and chromium state this will improve with chromium 107,electron 22.

* all under native wayland

Related Issue: https://github.com/jitsi/jitsi-meet-electron/issues/808


---

Additional information on my system:

* Debian Sid
* xdg-desktop-portal-gnome Version 43.1-1 
* flatpak Version: 1.14.1-1
* pipewire Version: 0.3.60-2
* flatpak jitsi Version: 2022.11.0

Works on Ubuntu 22.10 too. 
