### PR TITLE
fix: popups for Google & Dropbox

### DIFF
--- a/main.js
+++ b/main.js
@@ -217,6 +217,12 @@ function createJitsiMeetWindow() {
 
         if (!target || target === 'browser') {
             openExternalLink(url);
+
+            return { action: 'deny' };
+        }
+
+        if (target === 'electron') {
+            return { action: 'allow' };
         }
 
         return { action: 'deny' };


### PR DESCRIPTION
broken likely since 542c7f089a241487a0c7bc7905e21db93c5bb13b (#787)
