### PR TITLE
ci: unpin upload-artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         npm ci
         npm run dist
-    - uses: actions/upload-artifact@v3.1.0
+    - uses: actions/upload-artifact@v3
       with:
         name: linux-binaries
         path: |
@@ -57,7 +57,7 @@ jobs:
         npm ci
         npm run lint
         npm run dist
-    - uses: actions/upload-artifact@v3.1.0
+    - uses: actions/upload-artifact@v3
       with:
         name: mac-binaries
         path: |
@@ -78,7 +78,7 @@ jobs:
       run: |
         npm ci
         npm run dist
-    - uses: actions/upload-artifact@v3.1.0
+    - uses: actions/upload-artifact@v3
       with:
         name: windows-binaries
         path: |


### PR DESCRIPTION
we use other core actions also just pinned to major version, no need to differentiate here for upload-artifact
