### PR TITLE
ci: move linting from slowest to fastest job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         npm ci
+        npm run lint
         npm run dist
     - uses: actions/upload-artifact@v3
       with:
@@ -55,7 +56,6 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         npm ci
-        npm run lint
         npm run dist
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
mac job is anyway the slowest, not add linting there as well
