### PR TITLE
feat(reload) refactor opening external links

### DIFF
--- a/app/preload/preload.js
+++ b/app/preload/preload.js
@@ -5,9 +5,18 @@ const { RemoteControl,
     initPopupsConfigurationRender,
     setupPowerMonitorRender
 } = require('@jitsi/electron-sdk');
-const { openExternalLink } = require('../features/utils/openExternalLink');
 
 const whitelistedIpcChannels = [ 'protocol-data-msg', 'renderer-ready' ];
+
+/**
+ * Open an external URL.
+ *
+ * @param {string} url - The URL we with to open.
+ * @returns {void}
+ */
+function openExternalLink(url) {
+    ipcRenderer.send('jitsi-open-url', url);
+}
 
 /**
  * Setup the renderer process.

--- a/main.js
+++ b/main.js
@@ -416,3 +416,10 @@ ipcMain.on('renderer-ready', () => {
             .send('protocol-data-msg', protocolDataForFrontApp);
     }
 });
+
+/**
+ * Handle opening external links in the main process.
+ */
+ipcMain.on('jitsi-open-url', (event, someUrl) => {
+    openExternalLink(someUrl);
+});


### PR DESCRIPTION
Use IPC to send a message to the main process instead of opening them from the renderer process.