### PR TITLE
chore(deps) update electron to 25.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "babel-loader": "^8.2.3",
         "concurrently": "5.1.0",
         "css-loader": "^6.7.1",
-        "electron": "24.2.0",
+        "electron": "25.2.0",
         "electron-builder": "23.1.0",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -6584,9 +6584,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-24.2.0.tgz",
-      "integrity": "sha512-fEYAftYqFhveniWJbEHXjNMWjooFFIuqNj/eEFJkGzycInfBJq/c4E/dew++s6s0YLubxFnjoF2qZiqapLj0gA==",
+      "version": "25.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-25.2.0.tgz",
+      "integrity": "sha512-I/rhcW2sV2fyiveVSBr2N7v5ZiCtdGY0UiNCDZgk2fpSC+irQjbeh7JT2b4vWmJ2ogOXBjqesrN9XszTIG6DHg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -20057,9 +20057,9 @@
       }
     },
     "electron": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-24.2.0.tgz",
-      "integrity": "sha512-fEYAftYqFhveniWJbEHXjNMWjooFFIuqNj/eEFJkGzycInfBJq/c4E/dew++s6s0YLubxFnjoF2qZiqapLj0gA==",
+      "version": "25.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-25.2.0.tgz",
+      "integrity": "sha512-I/rhcW2sV2fyiveVSBr2N7v5ZiCtdGY0UiNCDZgk2fpSC+irQjbeh7JT2b4vWmJ2ogOXBjqesrN9XszTIG6DHg==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "babel-loader": "^8.2.3",
     "concurrently": "5.1.0",
     "css-loader": "^6.7.1",
-    "electron": "24.2.0",
+    "electron": "25.2.0",
     "electron-builder": "23.1.0",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Contains bump to electron 25, see https://www.electronjs.org/blog/electron-25-0
for details
