### PR TITLE
chore(deps) update electron to 25.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "babel-loader": "^8.2.3",
         "concurrently": "5.1.0",
         "css-loader": "^6.7.1",
-        "electron": "25.2.0",
+        "electron": "25.3.0",
         "electron-builder": "23.1.0",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -6584,9 +6584,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "25.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-25.2.0.tgz",
-      "integrity": "sha512-I/rhcW2sV2fyiveVSBr2N7v5ZiCtdGY0UiNCDZgk2fpSC+irQjbeh7JT2b4vWmJ2ogOXBjqesrN9XszTIG6DHg==",
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-25.3.0.tgz",
+      "integrity": "sha512-cyqotxN+AroP5h2IxUsJsmehYwP5LrFAOO7O7k9tILME3Sa1/POAg3shrhx4XEnaAMyMqMLxzGvkzCVxzEErnA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -20057,9 +20057,9 @@
       }
     },
     "electron": {
-      "version": "25.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-25.2.0.tgz",
-      "integrity": "sha512-I/rhcW2sV2fyiveVSBr2N7v5ZiCtdGY0UiNCDZgk2fpSC+irQjbeh7JT2b4vWmJ2ogOXBjqesrN9XszTIG6DHg==",
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-25.3.0.tgz",
+      "integrity": "sha512-cyqotxN+AroP5h2IxUsJsmehYwP5LrFAOO7O7k9tILME3Sa1/POAg3shrhx4XEnaAMyMqMLxzGvkzCVxzEErnA==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "babel-loader": "^8.2.3",
     "concurrently": "5.1.0",
     "css-loader": "^6.7.1",
-    "electron": "25.2.0",
+    "electron": "25.3.0",
     "electron-builder": "23.1.0",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Contains the fix for the hard crash on wayland when starting screenshare. Unfortunately it now hard-crashes when stopping screensharing.

The hard crash on starting screensharing is fixed, but its still relatively unreliable to share the screen under wayland. Background is https://github.com/electron/electron/issues/39043, and same as described there two Pipewire pickers open, and the user has to select and accept both, then be quick in the jitsi selector as well and then it works. If one Pipewire picker is cancelled by the user, the process hangs. If the user is too slow in the jitsi selector, the two Pipewire pickers pop up again.

See: #829
