### PR TITLE
chore(deps) update electron to 26.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "babel-loader": "^8.2.3",
         "concurrently": "5.1.0",
         "css-loader": "^6.7.1",
-        "electron": "25.3.0",
+        "electron": "26.1.0",
         "electron-builder": "24.4.0",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -6946,9 +6946,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-25.3.0.tgz",
-      "integrity": "sha512-cyqotxN+AroP5h2IxUsJsmehYwP5LrFAOO7O7k9tILME3Sa1/POAg3shrhx4XEnaAMyMqMLxzGvkzCVxzEErnA==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-26.1.0.tgz",
+      "integrity": "sha512-qEh19H09Pysn3ibms5nZ0haIh5pFoOd7/5Ww7gzmAwDQOulRi8Sa2naeueOyIb1GKpf+6L4ix3iceYRAuA5r5Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -21281,9 +21281,9 @@
       }
     },
     "electron": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-25.3.0.tgz",
-      "integrity": "sha512-cyqotxN+AroP5h2IxUsJsmehYwP5LrFAOO7O7k9tILME3Sa1/POAg3shrhx4XEnaAMyMqMLxzGvkzCVxzEErnA==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-26.1.0.tgz",
+      "integrity": "sha512-qEh19H09Pysn3ibms5nZ0haIh5pFoOd7/5Ww7gzmAwDQOulRi8Sa2naeueOyIb1GKpf+6L4ix3iceYRAuA5r5Q==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "babel-loader": "^8.2.3",
     "concurrently": "5.1.0",
     "css-loader": "^6.7.1",
-    "electron": "25.3.0",
+    "electron": "26.1.0",
     "electron-builder": "24.4.0",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Contains the fix for the pipewire selector. Its now a combined selector, same as Chrome/Firefox, and contains the fix for the hard crash on wayland when stopping screenshare. Unfortunately sharing the full screen still does not work under wayland, only sharing individual windows (tested with Ubuntu 22.04).

Sharing a windows is still very cumbersome, as one needs to select the
window in the pipewire selector, then quickly select it in the jitsi
built-in selector as well and then it works. If one is too slow (>2
seconds) on the second selector, the pipewire selector comes up again.

See: #829
