### PR TITLE
fix(linux): downgrade electron to avoid renderer crashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "babel-loader": "^8.2.3",
         "concurrently": "5.1.0",
         "css-loader": "^6.7.1",
-        "electron": "26.1.0",
+        "electron": "25.8.1",
         "electron-builder": "24.4.0",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -6946,9 +6946,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-26.1.0.tgz",
-      "integrity": "sha512-qEh19H09Pysn3ibms5nZ0haIh5pFoOd7/5Ww7gzmAwDQOulRi8Sa2naeueOyIb1GKpf+6L4ix3iceYRAuA5r5Q==",
+      "version": "25.8.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-25.8.1.tgz",
+      "integrity": "sha512-GtcP1nMrROZfFg0+mhyj1hamrHvukfF6of2B/pcWxmWkd5FVY1NJib0tlhiorFZRzQN5Z+APLPr7aMolt7i2AQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -21281,9 +21281,9 @@
       }
     },
     "electron": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-26.1.0.tgz",
-      "integrity": "sha512-qEh19H09Pysn3ibms5nZ0haIh5pFoOd7/5Ww7gzmAwDQOulRi8Sa2naeueOyIb1GKpf+6L4ix3iceYRAuA5r5Q==",
+      "version": "25.8.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-25.8.1.tgz",
+      "integrity": "sha512-GtcP1nMrROZfFg0+mhyj1hamrHvukfF6of2B/pcWxmWkd5FVY1NJib0tlhiorFZRzQN5Z+APLPr7aMolt7i2AQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "babel-loader": "^8.2.3",
     "concurrently": "5.1.0",
     "css-loader": "^6.7.1",
-    "electron": "26.1.0",
+    "electron": "25.8.1",
     "electron-builder": "24.4.0",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Downgrade to electron 25 to avoid renderer crashes on Arch and Fedora.
See upstream https://github.com/electron/electron/issues/39775

Fixes: #908
