### PR TITLE
chore(deps) update electron to 25.8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ On macOS Catalina, a warning will be displayed on first install. The app won't o
 * If you can't execute the file directly after downloading it, try running `chmod u+x ./jitsi-meet-x86_64.AppImage`
 
 * Under wayland, screensharing is currently buggy:
-  * When trying to start screensharing under wayland, 2 permission popups will show up. First two pipewire based system selectors, then a jitsi internal selector. You need to select something in both (overlapping) Pipewire promots. In the following jitsi-internal selector, be quick (<2 seconds) to select a screen or an application to start the screensharing. If you take longer, then the first permission pupups will come again.
-  * X11 is not affected by this
+  * Sharing a full screen is not possible
+  * When trying to start screensharing under wayland, 2 permission popups will show up. First a pipewire based system selector, then a jitsi internal selector. Select an application window in the first selector and then the same in the jitsi internal selector. Sharing application windows works via this, sharing a full screen unfortunately not.
 
 * On Ubuntu 22.04, the AppImage will fail with a fuse error (as the AppImage uses `libfuse2`, while 22.04 comes with `libfuse3` by default):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "babel-loader": "^8.2.3",
         "concurrently": "5.1.0",
         "css-loader": "^6.7.1",
-        "electron": "25.8.1",
+        "electron": "25.8.4",
         "electron-builder": "24.4.0",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -6946,9 +6946,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "25.8.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-25.8.1.tgz",
-      "integrity": "sha512-GtcP1nMrROZfFg0+mhyj1hamrHvukfF6of2B/pcWxmWkd5FVY1NJib0tlhiorFZRzQN5Z+APLPr7aMolt7i2AQ==",
+      "version": "25.8.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-25.8.4.tgz",
+      "integrity": "sha512-hUYS3RGdaa6E1UWnzeGnsdsBYOggwMMg4WGxNGvAoWtmRrr6J1BsjFW/yRq4WsJHJce2HdzQXtz4OGXV6yUCLg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -21281,9 +21281,9 @@
       }
     },
     "electron": {
-      "version": "25.8.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-25.8.1.tgz",
-      "integrity": "sha512-GtcP1nMrROZfFg0+mhyj1hamrHvukfF6of2B/pcWxmWkd5FVY1NJib0tlhiorFZRzQN5Z+APLPr7aMolt7i2AQ==",
+      "version": "25.8.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-25.8.4.tgz",
+      "integrity": "sha512-hUYS3RGdaa6E1UWnzeGnsdsBYOggwMMg4WGxNGvAoWtmRrr6J1BsjFW/yRq4WsJHJce2HdzQXtz4OGXV6yUCLg==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "babel-loader": "^8.2.3",
     "concurrently": "5.1.0",
     "css-loader": "^6.7.1",
-    "electron": "25.8.1",
+    "electron": "25.8.4",
     "electron-builder": "24.4.0",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Main change: backport of merged Pipewire picker under wayland. Now
redundant pickers for screen and application windows does not popup,
unfortunately full screen sharing is no longer possible with this.

See: #829
