### PR TITLE
chore(deps) update electron to 27.0.4

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,9 +40,9 @@ app.commandLine.appendSwitch('disable-features', 'DesktopCaptureMacV2,IOSurfaceC
 // Enable Opus RED field trial.
 app.commandLine.appendSwitch('force-fieldtrials', 'WebRTC-Audio-Red-For-Opus/Enabled/');
 
-// Wayland: Enable optional PipeWire and window decorations support.
+// Wayland: Enable optional PipeWire support.
 if (!app.commandLine.hasSwitch('enable-features')) {
-    app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer,WaylandWindowDecorations');
+    app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer');
 }
 
 autoUpdater.logger = require('electron-log');

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "babel-loader": "^8.2.3",
         "concurrently": "5.1.0",
         "css-loader": "^6.7.1",
-        "electron": "25.8.4",
+        "electron": "27.0.4",
         "electron-builder": "24.4.0",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -6965,9 +6965,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "25.8.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-25.8.4.tgz",
-      "integrity": "sha512-hUYS3RGdaa6E1UWnzeGnsdsBYOggwMMg4WGxNGvAoWtmRrr6J1BsjFW/yRq4WsJHJce2HdzQXtz4OGXV6yUCLg==",
+      "version": "27.0.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-27.0.4.tgz",
+      "integrity": "sha512-ob29rN1mtiyAXzF8HsHd5jh8bYKd9OQDakfdOExi0F7epU97gXPHaj6JPjbBJ/vpki5d32SyKVePW4vxeNZk1A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -21323,9 +21323,9 @@
       }
     },
     "electron": {
-      "version": "25.8.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-25.8.4.tgz",
-      "integrity": "sha512-hUYS3RGdaa6E1UWnzeGnsdsBYOggwMMg4WGxNGvAoWtmRrr6J1BsjFW/yRq4WsJHJce2HdzQXtz4OGXV6yUCLg==",
+      "version": "27.0.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-27.0.4.tgz",
+      "integrity": "sha512-ob29rN1mtiyAXzF8HsHd5jh8bYKd9OQDakfdOExi0F7epU97gXPHaj6JPjbBJ/vpki5d32SyKVePW4vxeNZk1A==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "babel-loader": "^8.2.3",
     "concurrently": "5.1.0",
     "css-loader": "^6.7.1",
-    "electron": "25.8.4",
+    "electron": "27.0.4",
     "electron-builder": "24.4.0",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Contains electron 26 and 27 updates, for details see

https://www.electronjs.org/blog/electron-26-0
https://www.electronjs.org/blog/electron-27-0

Contains a fix for Linux that lead to crashes when the graphics drivers changed
https://github.com/electron/electron/pull/40467

Mainly this should help with further bugfixes in webrtc as the contained
Chromium is implicitly upgraded from 114 to 118.

In wayland / pipewire terms we have only minor additions, eg:

WaylandWindowDecorations by default: https://github.com/electron/electron/pull/39582
