### PR TITLE
chore(deps) update electron to 28.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "babel-loader": "^8.2.3",
         "concurrently": "5.1.0",
         "css-loader": "^6.7.1",
-        "electron": "27.0.4",
+        "electron": "28.1.0",
         "electron-builder": "24.4.0",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -6965,9 +6965,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "27.0.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-27.0.4.tgz",
-      "integrity": "sha512-ob29rN1mtiyAXzF8HsHd5jh8bYKd9OQDakfdOExi0F7epU97gXPHaj6JPjbBJ/vpki5d32SyKVePW4vxeNZk1A==",
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-28.1.0.tgz",
+      "integrity": "sha512-82Y7o4PSWPn1o/aVwYPsgmBw6Gyf2lVHpaBu3Ef8LrLWXxytg7ZRZr/RtDqEMOzQp3+mcuy3huH84MyjdmP50Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -21323,9 +21323,9 @@
       }
     },
     "electron": {
-      "version": "27.0.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-27.0.4.tgz",
-      "integrity": "sha512-ob29rN1mtiyAXzF8HsHd5jh8bYKd9OQDakfdOExi0F7epU97gXPHaj6JPjbBJ/vpki5d32SyKVePW4vxeNZk1A==",
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-28.1.0.tgz",
+      "integrity": "sha512-82Y7o4PSWPn1o/aVwYPsgmBw6Gyf2lVHpaBu3Ef8LrLWXxytg7ZRZr/RtDqEMOzQp3+mcuy3huH84MyjdmP50Q==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "babel-loader": "^8.2.3",
     "concurrently": "5.1.0",
     "css-loader": "^6.7.1",
-    "electron": "27.0.4",
+    "electron": "28.1.0",
     "electron-builder": "24.4.0",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Chromium updated from 118 to 120

Added support for ELECTRON_OZONE_PLATFORM_HINT environment variable on Linux

For all electron details, see https://www.electronjs.org/blog/electron-28-0
