### PR TITLE
fix(main): filter out frame-ancestors if exists in Content-Security-Policy

### DIFF
--- a/main.js
+++ b/main.js
@@ -272,6 +272,15 @@ function createJitsiMeetWindow() {
             details.responseHeaders['content-security-policy'] = [ cspFiltered ];
         }
 
+        if (details.responseHeaders['Content-Security-Policy']) {
+            const cspFiltered = details.responseHeaders['Content-Security-Policy'][0]
+                .split(';')
+                .filter(x => x.indexOf('frame-ancestors') === -1)
+                .join(';');
+
+            details.responseHeaders['Content-Security-Policy'] = [ cspFiltered ];
+        }
+
         callback({
             responseHeaders: details.responseHeaders
         });


### PR DESCRIPTION
The application filters out `frame-ancestors` if it exists in `content-security-policy` but it doesn't check `Content-Security-Policy` (_with uppercase for the first letter_) which is the recommend style in most guides.

In our use-case, we integrate `Jitsi` with our `Keycloak` server as identity provider and it uses `Content-Security-Policy`. So, it doesn't work if the application doesn't have this update.