### PR TITLE
dev: get electron-reload back to work

### DIFF
--- a/patches/electron-reload+1.5.0.patch
+++ b/patches/electron-reload+1.5.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/electron-reload/main.js b/node_modules/electron-reload/main.js
+index 688934d..860e071 100644
+--- a/node_modules/electron-reload/main.js
++++ b/node_modules/electron-reload/main.js
+@@ -9,7 +9,7 @@ const ignoredPaths = /node_modules|[/\\]\./
+ // only effective when the process is restarted (hard reset)
+ // We assume that electron-reload is required by the main
+ // file of the electron application
+-const mainFile = module.parent.filename
++const mainFile = 'build/main.js'
+ 
+ /**
+  * Creates a callback for hard resets.


### PR DESCRIPTION
we lost that somewhere as part of webpack upgrades I guess,
and I could not get it to work by configuring webpack differently,
but just removing the line in question works and the reload
also still works afterwards.

Signed-off-by: Christoph Settgast <csett86_git@quicksands.de>
