### PR TITLE
ci: update to macos-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           dist/latest-linux-arm64.yml
   build-mac:
     name: macOS
-    runs-on: macos-11
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4


### PR DESCRIPTION
macos-11 is being deprecated, lets use the opportunity to jump to M1 based macos-14 (Sonoma)