### PR TITLE
chore(deps) update electron to 30.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "babel-loader": "^8.2.3",
         "concurrently": "5.1.0",
         "css-loader": "^6.7.1",
-        "electron": "30.0.3",
+        "electron": "30.1.0",
         "electron-builder": "24.13.3",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -6523,9 +6523,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-30.0.3.tgz",
-      "integrity": "sha512-h+suwx6e0fnv/9wi0/cmCMtG+4LrPzJZa+3DEEpxcPcP+pcWnBI70t8QspxgMNIh2wzXLMD9XVqrLkEbiBAInw==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-30.1.0.tgz",
+      "integrity": "sha512-9O8m7kinjwMH5Df0hpXbwUaqI6pk3aJm1sKQUkQGCF7NDbNkGhu2BXgqaicPU6oe26zQPc5vtwWnHmiKlh1hYA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -19776,9 +19776,9 @@
       }
     },
     "electron": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-30.0.3.tgz",
-      "integrity": "sha512-h+suwx6e0fnv/9wi0/cmCMtG+4LrPzJZa+3DEEpxcPcP+pcWnBI70t8QspxgMNIh2wzXLMD9XVqrLkEbiBAInw==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-30.1.0.tgz",
+      "integrity": "sha512-9O8m7kinjwMH5Df0hpXbwUaqI6pk3aJm1sKQUkQGCF7NDbNkGhu2BXgqaicPU6oe26zQPc5vtwWnHmiKlh1hYA==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "babel-loader": "^8.2.3",
     "concurrently": "5.1.0",
     "css-loader": "^6.7.1",
-    "electron": "30.0.3",
+    "electron": "30.1.0",
     "electron-builder": "24.13.3",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
No major update, but smaller fixes, including crashes when maximising
with X11.

For all details see https://releases.electronjs.org/release/compare/v30.0.3/v30.1.0

Fixes: #962
