### PR TITLE
fix(conference) disable calendar integration

### DIFF
--- a/app/features/conference/components/Conference.js
+++ b/app/features/conference/components/Conference.js
@@ -213,6 +213,7 @@ class Conference extends Component<Props, State> {
         // and new one for newly setup servers where the new option overrides
         // the old if set.
         const configOverwrite = {
+            enableCalendarIntegration: false,
             disableAGC: this.props._disableAGC,
             prejoinPageEnabled: true,
             prejoinConfig: {


### PR DESCRIPTION
It's not functional from within the Electron client since it doesn't render the welcome page.

Fixes: https://github.com/jitsi/jitsi-meet-electron/issues/974