### PR TITLE
chore(deps) update electron to 33.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "babel-loader": "^8.2.3",
         "concurrently": "5.1.0",
         "css-loader": "^6.7.1",
-        "electron": "32.1.2",
+        "electron": "33.3.1",
         "electron-builder": "24.13.3",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -6297,12 +6297,11 @@
       }
     },
     "node_modules/electron": {
-      "version": "32.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-32.1.2.tgz",
-      "integrity": "sha512-CXe6doFzhmh1U7daOvUzmF6Cj8hssdYWMeEPRnRO6rB9/bbwMlWctcQ7P8NJXhLQ88/vYUJQrJvlJPh8qM0BRQ==",
+      "version": "33.3.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-33.3.1.tgz",
+      "integrity": "sha512-Z7l2bVgpdKxHQMI4i0CirBX2n+iCYKOx5mbzNM3BpOyFELwlobEXKmzCmEnwP+3EcNeIhUQyIEBFQxN06QgdIw==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^20.9.0",
@@ -18278,9 +18277,9 @@
       }
     },
     "electron": {
-      "version": "32.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-32.1.2.tgz",
-      "integrity": "sha512-CXe6doFzhmh1U7daOvUzmF6Cj8hssdYWMeEPRnRO6rB9/bbwMlWctcQ7P8NJXhLQ88/vYUJQrJvlJPh8qM0BRQ==",
+      "version": "33.3.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-33.3.1.tgz",
+      "integrity": "sha512-Z7l2bVgpdKxHQMI4i0CirBX2n+iCYKOx5mbzNM3BpOyFELwlobEXKmzCmEnwP+3EcNeIhUQyIEBFQxN06QgdIw==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "babel-loader": "^8.2.3",
     "concurrently": "5.1.0",
     "css-loader": "^6.7.1",
-    "electron": "32.1.2",
+    "electron": "33.3.1",
     "electron-builder": "24.13.3",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
Contains electron 33 update, for details see

Due to the updated Chromium inside,
this removes support for macOS 10.15,
now macOS 11+ is required

https://www.electronjs.org/blog/electron-33-0
