### PR TITLE
feat(macOS) drop no longer needed entitlements

### DIFF
--- a/entitlements.mac.plist
+++ b/entitlements.mac.plist
@@ -6,8 +6,6 @@
     <true/>
     <key>com.apple.security.device.camera</key>
     <true/>
-    <key>com.apple.security.device.microphone</key>
-    <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
 </dict>

--- a/entitlements.mac.plist
+++ b/entitlements.mac.plist
@@ -4,8 +4,6 @@
 <dict>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
     <key>com.apple.security.device.camera</key>
     <true/>
     <key>com.apple.security.device.microphone</key>

--- a/entitlements.mac.plist
+++ b/entitlements.mac.plist
@@ -6,10 +6,6 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
     <key>com.apple.security.device.camera</key>
     <true/>
     <key>com.apple.security.device.microphone</key>


### PR DESCRIPTION
These were added to support 3rd party (unsigned) virtual camera plugins, but with Apple tightening the delivery of unsigned code we shouldn't really open that door anymore.