### PR TITLE
Enable pipewire camera support

### DIFF
--- a/main.js
+++ b/main.js
@@ -50,7 +50,7 @@ app.commandLine.appendSwitch('force-fieldtrials', 'WebRTC-Audio-Red-For-Opus/Ena
 
 // Wayland: Enable optional PipeWire support.
 if (!app.commandLine.hasSwitch('enable-features')) {
-    app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer');
+    app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer,WebRtcPipeWireCamera');
 }
 
 autoUpdater.logger = require('electron-log');


### PR DESCRIPTION
The features is integrated on chrome since a long time (still disabled by default)
Will probably be needed going forward has desktop on Linux add indicator for the usage of camera and microphone and rely on Pipewire to know if it's used.
Not saying that it need to be merged right now bc I don't know how stable it is from upstream chrome. 
Happily having my desktop indicator on my desktop still :-D