### PR TITLE
deps: Electron 35 -> 37 update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "babel-loader": "^8.2.3",
         "concurrently": "5.1.0",
         "css-loader": "^6.7.1",
-        "electron": "35.1.5",
+        "electron": "37.3.1",
         "electron-builder": "26.0.12",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -74,7 +74,7 @@
         "webpack-cli": "^4.9.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7960,9 +7960,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "35.1.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-35.1.5.tgz",
-      "integrity": "sha512-LolvbKKQUSCGvEwbEQNt1cxD1t+YYClDNwBIjn4d28KM8FSqUn9zJuf6AbqNA7tVs9OFl/EQpmg/m4lZV1hH8g==",
+      "version": "37.3.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.3.1.tgz",
+      "integrity": "sha512-7DhktRLqhe6OJh/Bo75bTI0puUYEmIwSzMinocgO63mx3MVjtIn2tYMzLmAleNIlud2htkjpsMG2zT4PiTCloA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -22722,9 +22722,9 @@
       }
     },
     "electron": {
-      "version": "35.1.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-35.1.5.tgz",
-      "integrity": "sha512-LolvbKKQUSCGvEwbEQNt1cxD1t+YYClDNwBIjn4d28KM8FSqUn9zJuf6AbqNA7tVs9OFl/EQpmg/m4lZV1hH8g==",
+      "version": "37.3.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.3.1.tgz",
+      "integrity": "sha512-7DhktRLqhe6OJh/Bo75bTI0puUYEmIwSzMinocgO63mx3MVjtIn2tYMzLmAleNIlud2htkjpsMG2zT4PiTCloA==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "babel-loader": "^8.2.3",
     "concurrently": "5.1.0",
     "css-loader": "^6.7.1",
-    "electron": "35.1.5",
+    "electron": "37.3.1",
     "electron-builder": "26.0.12",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
For details see
https://www.electronjs.org/blog/electron-36-0
https://www.electronjs.org/blog/electron-37-0

Essentially this upgrades the contained Chromium from 134 to 138

Signed-off-by: Christoph Settgast <csett86_git@quicksands.de>
