### PR TITLE
Revert "Enable pipewire camera support"

### DIFF
--- a/main.js
+++ b/main.js
@@ -51,7 +51,7 @@ app.commandLine.appendSwitch('force-fieldtrials', 'WebRTC-Audio-Red-For-Opus/Ena
 
 // Wayland: Enable optional PipeWire support.
 if (!app.commandLine.hasSwitch('enable-features')) {
-    app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer,WebRtcPipeWireCamera');
+    app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer');
 }
 
 autoUpdater.logger = require('electron-log');


### PR DESCRIPTION
Reverts jitsi/jitsi-meet-electron#1026

Seems to cause many problems: https://github.com/jitsi/jitsi-meet-electron/issues/1037