### PR TITLE
fix: pass windowOpenHandler to initPopupsConfigurationMain

### DIFF
--- a/main.js
+++ b/main.js
@@ -239,8 +239,6 @@ function createJitsiMeetWindow() {
     windowState.manage(mainWindow);
     mainWindow.loadURL(indexURL);
 
-    mainWindow.webContents.setWindowOpenHandler(windowOpenHandler);
-
     if (isDev) {
         mainWindow.webContents.session.clearCache();
     }
@@ -321,7 +319,7 @@ function createJitsiMeetWindow() {
         callback(true);
     });
 
-    initPopupsConfigurationMain(mainWindow);
+    initPopupsConfigurationMain(mainWindow, windowOpenHandler);
     setupPictureInPictureMain(mainWindow);
     setupPowerMonitorMain(mainWindow);
     setupScreenSharingMain(mainWindow, config.default.appName, pkgJson.build.appId);


### PR DESCRIPTION
- Fix authentication popup not opening browser after SDK 9 update
- Pass windowOpenHandler as second argument to initPopupsConfigurationMain() so non-OAuth window.open requests are properly delegated
- Remove redundant setWindowOpenHandler() call that was being overwritten

Fixes #1073
