### PR TITLE
mac: prepare desktop audio capture

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
       "extendInfo": {
         "NSCameraUsageDescription": "Jitsi Meet requires access to your camera in order to make video-calls.",
         "NSMicrophoneUsageDescription": "Jitsi Meet requires access to your microphone in order to make calls (audio/video).",
+        "NSAudioCaptureUsageDescription": "Jitsi Meet can share your system audio via screensharing if you enable it.",
         "LSMultipleInstancesProhibited": true
       }
     },


### PR DESCRIPTION
With https://github.com/electron/electron/pull/49717 the desktopCapturer
supports system audio for macOS 13 and above. Is was recently fixed
in https://github.com/electron/electron/pull/49740 for current
electron.

This is a preparational step, but:

This on its own does not allow audio for screenshare, as its currently
hard-coded to only show the "Share Audio" button on windows, see
https://github.com/jitsi/jitsi-meet/blob/master/react/features/screen-share/functions.ts#L34
