### PR TITLE
fix: decode URL encoded room names in recent conference rooms list

### DIFF
--- a/app/features/recent-list/components/RecentList.js
+++ b/app/features/recent-list/components/RecentList.js
@@ -86,7 +86,7 @@ class RecentList extends Component {
                 key = { conference.startTime }
                 onClick = { this._onNavigateToConference(conference) }>
                 <ConferenceTitle>
-                    { conference.room }
+                    { decodeURIComponent(conference.room) }
                 </ConferenceTitle>
                 <TruncatedText>
                     { this._renderServerURL(conference.serverURL) }


### PR DESCRIPTION
Room names containing spaces were displayed as URL encoded
values in the recent conference rooms list.

Example:
Before: Hey%20There%20Its%20Me
After:  Hey There Its Me

This PR decodes the room name using decodeURIComponent()
before rendering it.