### PR TITLE
feat: add --defaultServer CLI option to set default server URL

### DIFF
--- a/app/features/app/components/App.js
+++ b/app/features/app/components/App.js
@@ -9,6 +9,7 @@ import { ConnectedRouter as Router, push } from 'react-router-redux';
 import { Conference } from '../../conference';
 import config from '../../config';
 import { history } from '../../router';
+import { setServerURL } from '../../settings';
 import { createConferenceObjectFromURL } from '../../utils';
 import { Welcome } from '../../welcome';
 
@@ -28,6 +29,7 @@ class App extends Component {
 
         this._listenOnProtocolMessages
             = this._listenOnProtocolMessages.bind(this);
+        this._onSetDefaultServer = this._onSetDefaultServer.bind(this);
 
         this._listeners = [];
     }
@@ -42,6 +44,11 @@ class App extends Component {
         const removeListener = window.jitsiNodeAPI.ipc.addListener('protocol-data-msg', this._listenOnProtocolMessages);
 
         this._listeners.push(removeListener);
+
+        const removeSetDefaultServerListener
+            = window.jitsiNodeAPI.ipc.addListener('set-default-server', this._onSetDefaultServer);
+
+        this._listeners.push(removeSetDefaultServerListener);
 
         // send notification to main process
         window.jitsiNodeAPI.ipc.send('renderer-ready');
@@ -59,6 +66,16 @@ class App extends Component {
         listeners.forEach(removeListener => removeListener());
     }
 
+
+    /**
+     * Handler for the set-default-server IPC message from the main process.
+     *
+     * @param {string} serverURL - The default server URL passed via CLI.
+     * @returns {void}
+     */
+    _onSetDefaultServer(serverURL) {
+        this.props.dispatch(setServerURL(serverURL));
+    }
 
     /**
      * Handler when main process contact us.

--- a/app/preload/preload.js
+++ b/app/preload/preload.js
@@ -7,7 +7,7 @@ const {
 } = require('@jitsi/electron-sdk');
 const { ipcRenderer } = require('electron');
 
-const whitelistedIpcChannels = [ 'protocol-data-msg', 'renderer-ready' ];
+const whitelistedIpcChannels = [ 'protocol-data-msg', 'renderer-ready', 'set-default-server' ];
 
 ipcRenderer.setMaxListeners(0);
 

--- a/main.js
+++ b/main.js
@@ -29,6 +29,26 @@ const pkgJson = require('./package.json');
 
 const showDevTools = Boolean(process.env.SHOW_DEV_TOOLS) || (process.argv.indexOf('--show-dev-tools') > -1);
 
+/**
+ * Parse --defaultServer CLI argument (supports both --defaultServer=URL and --defaultServer URL).
+ * In dev mode via `npm start`, arguments passed via `npm start -- --defaultServer` are consumed
+ * by `concurrently` and never reach the Electron process. Use the JITSI_DEFAULT_SERVER
+ * environment variable for dev mode instead (mirrors the SHOW_DEV_TOOLS pattern).
+ * Dev usage: $env:JITSI_DEFAULT_SERVER='https://example.com'; npm start
+ */
+const defaultServerArgIdx = process.argv.findIndex(arg => arg.startsWith('--defaultServer'));
+let defaultServerURL = process.env.JITSI_DEFAULT_SERVER || null;
+
+if (defaultServerArgIdx > -1) {
+    const arg = process.argv[defaultServerArgIdx];
+
+    if (arg.includes('=')) {
+        defaultServerURL = arg.split('=')[1] || null;
+    } else if (process.argv[defaultServerArgIdx + 1] && !process.argv[defaultServerArgIdx + 1].startsWith('--')) {
+        defaultServerURL = process.argv[defaultServerArgIdx + 1];
+    }
+}
+
 // For enabling remote control, please change the ENABLE_REMOTE_CONTROL flag in
 // app/features/conference/components/Conference.js to true as well
 const ENABLE_REMOTE_CONTROL = false;
@@ -480,6 +500,9 @@ ipcMain.on('renderer-ready', () => {
         mainWindow
             .webContents
             .send('protocol-data-msg', protocolDataForFrontApp);
+    }
+    if (defaultServerURL) {
+        mainWindow.webContents.send('set-default-server', defaultServerURL);
     }
 });
 


### PR DESCRIPTION
### Summary

Adds support for a `--defaultServer` CLI option to specify the default Jitsi server URL when launching the Electron app.

This allows unattended or enterprise deployments to launch the application directly connected to a custom Jitsi deployment instead of the default `https://meet.jit.si`.

Closes #1048

### Implementation

- Parse `--defaultServer` in the Electron main process (also supports `JITSI_DEFAULT_SERVER` for development mode).
- When provided, the value is sent to the renderer via the existing `set-default-server` IPC channel after `renderer-ready`.
- The renderer dispatches `setServerURL(serverURL)` to update the Redux settings store.
- Since `Conference.js` prefers `state.settings.serverURL`, the conference connection uses the provided server instead of the default.

This avoids introducing additional persistence (e.g. `electron-store`) and reuses the existing Redux settings mechanism.

### Previous PR context

The previous PR (#1049) implemented this using `electron-store`. During review it was suggested to avoid introducing another persistence layer since the server URL is already persisted through the renderer’s Redux settings store. This implementation follows that approach and reuses the existing settings flow instead.

### Usage

### Packaged builds

The CLI option works when launching the packaged application: 

`jitsi-meet-electron --defaultServer https://my.company.meet`

Both formats are supported:

`jitsi-meet-electron --defaultServer=https://my.company.meet`
`jitsi-meet-electron --defaultServer https://my.company.meet`

### Development mode
When running the app with `npm start`, CLI arguments cannot reach the Electron process due to the project’s `start` script using `concurrently.`

Current script: `webpack ... && concurrently "npm:watch" "electron ./build/main.js"`

Running: `npm start -- --defaultServer https://example.com`

actually executes: `webpack ... && concurrently "npm:watch" "electron ./build/main.js" --defaultServer https://example.com`

In this case the flag is passed to concurrently, not to Electron, so process.argv inside the Electron main process never receives it.

Because of this limitation, development mode supports an environment variable (following the existing pattern used for SHOW_DEV_TOOLS):

`JITSI_DEFAULT_SERVER=https://example.com npm start`

or

Windows PowerShell: 

`$env:JITSI_DEFAULT_SERVER="https://example.com"; npm start`

### Testing 

Development mode: `JITSI_DEFAULT_SERVER=https://meet.ffmuc.net npm start`
or 
on Windows PowerShell: `$env:JITSI_DEFAULT_SERVER="https://meet.ffmuc.net"; npm start`

Direct Electron run: `npx electron build/main.js --defaultServer https://meet.ffmuc.net`

Packaged application: `jitsi-meet-electron --defaultServer https://meet.ffmuc.net`

Expected behavior:

The application connects using the specified server, for example:

Using service URL wss://meet.ffmuc.net/xmpp-websocket instead of the default meet.jit.si.
