### PR TITLE
fix: resolve moderator sign-in loop caused by two-window layout

### DIFF
--- a/app/features/app/components/MeetingApp.js
+++ b/app/features/app/components/MeetingApp.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 
 import { Conference } from '../../conference';
 import config from '../../config';
+import { createConferenceObjectFromURL } from '../../utils';
 
 /**
  * Main component encapsulating the Meeting Window application.
@@ -56,6 +57,24 @@ class MeetingApp extends Component {
             }
         );
 
+        this._removeProtocolDataListener = window.jitsiNodeAPI.ipc.addListener(
+            'protocol-data-msg',
+            inputURL => {
+                let parsedURL = inputURL;
+
+                // Remove trailing slash if one exists.
+                if (parsedURL.slice(-1) === '/') {
+                    parsedURL = parsedURL.slice(0, -1);
+                }
+
+                const conference = createConferenceObjectFromURL(parsedURL);
+
+                if (conference && conference.room) {
+                    this.setState({ conference });
+                }
+            }
+        );
+
         // send notification to main process
         window.jitsiNodeAPI.ipc.send('renderer-ready');
     }
@@ -68,6 +87,10 @@ class MeetingApp extends Component {
     componentWillUnmount() {
         if (this._removeConferenceListener) {
             this._removeConferenceListener();
+        }
+
+        if (this._removeProtocolDataListener) {
+            this._removeProtocolDataListener();
         }
     }
 

--- a/main.js
+++ b/main.js
@@ -358,13 +358,19 @@ function handleProtocolCall(fullProtocolCall) {
 
     const inputURL = fullProtocolCall.replace(appProtocolSurplus, '');
 
+    if (meetingWindow) {
+        meetingWindow.webContents.send('protocol-data-msg', inputURL);
+
+        return;
+    }
+
     if (app.isReady() && mainWindow === null) {
         createJitsiMeetWindow();
     }
 
     protocolDataForFrontApp = inputURL;
 
-    if (rendererReady) {
+    if (rendererReady && mainWindow) {
         mainWindow
             .webContents
             .send('protocol-data-msg', inputURL);
@@ -415,17 +421,20 @@ app.on('second-instance', (event, commandLine) => {
      * If someone creates second instance of the application, set focus on
      * existing window.
      */
-    if (mainWindow) {
+    if (meetingWindow) {
+        meetingWindow.isMinimized() && meetingWindow.restore();
+        meetingWindow.focus();
+    } else if (mainWindow) {
         mainWindow.isMinimized() && mainWindow.restore();
         mainWindow.focus();
-
-        /**
-         * This is for windows [win32]
-         * so when someone tries to enter something like jitsi-meet://test
-         * while app is opened it will trigger protocol handler.
-         */
-        handleProtocolCall(commandLine.pop());
     }
+
+    /**
+     * This is for windows [win32]
+     * so when someone tries to enter something like jitsi-meet://test
+     * while app is opened it will trigger protocol handler.
+     */
+    handleProtocolCall(commandLine.pop());
 });
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
This PR fixes the regression introduced by the two-window layout (#1087) where the JWT authentication token was lost after signing in as a moderator via the browser. The second-instance handler has been updated to intercept deep-links even when the Launcher is closed, and MeetingApp.js has been hooked up to natively receive the protocol-data-msg payload to seamlessly upgrade the connection.